### PR TITLE
Decouple `wait_for_readiness` from CLI parsing && fix minor typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Options:
       --num-blocks <NUM_BLOCKS>  Number of blocks to test from the tip [default: 32]
       --use-reth                 Whether to query reth namespace
       --use-tracing              Whether to query tracing methods
-      --use-all-txes             Whether to query every transacion from a block or just the first
+      --use-all-txes             Whether to query every transaction from a block or just the first
       --rate-limit <RATE_LIMIT>  Maximum requests per second (rate limit)
       --timeout <TIMEOUT>        Maximum time to wait for syncing in seconds [default: 300]
   -h, --help                     Print help

--- a/crates/rpc-tester-cli/src/main.rs
+++ b/crates/rpc-tester-cli/src/main.rs
@@ -35,7 +35,7 @@ pub struct CliArgs {
     #[arg(long, value_name = "TRACING", default_value = "false")]
     pub use_tracing: bool,
 
-    /// Whether to query every transacion from a block or just the first.
+    /// Whether to query every transaction from a block or just the first.
     #[arg(long, value_name = "ALL_TXES", default_value = "false")]
     pub use_all_txes: bool,
 
@@ -69,7 +69,9 @@ async fn main() -> eyre::Result<()> {
         .network::<AnyNetwork>()
         .on_http(args.rpc2);
 
-    let block_range = wait_for_readiness(&rpc1, &rpc2, args.num_blocks).await?;
+    let timeout = Duration::from_secs(args.timeout);
+
+    let block_range = wait_for_readiness(&rpc1, &rpc2, args.num_blocks, timeout).await?;
 
     RpcTester::builder(rpc1, rpc2)
         .with_tracing(args.use_tracing)
@@ -87,17 +89,16 @@ pub async fn wait_for_readiness<P: Provider<AnyNetwork>>(
     rpc1: &P,
     rpc2: &P,
     block_size_range: u64,
+    timeout: Duration,
 ) -> eyre::Result<RangeInclusive<u64>> {
-    let args = CliArgs::parse();
     let start_time = Instant::now();
-    let timeout = Duration::from_secs(args.timeout);
 
     // Waits until it's done syncing
     while let SyncStatus::Info(sync_info) = rpc1.syncing().await? {
         if start_time.elapsed() > timeout {
             return Err(eyre::eyre!(
                 "Timeout waiting for rpc1 to sync after {} seconds",
-                args.timeout
+                timeout.as_secs()
             ));
         }
         info!(?sync_info, "rpc1 still syncing");


### PR DESCRIPTION
This PR removes the direct `CliArgs::parse()` call from `wait_for_readiness` and instead passes `timeout` as a parameter from `main`.

Previously, `wait_for_readiness` re-parsed CLI arguments internally to access the `timeout` value. This created tight coupling between the function and the CLI layer.

Although this worked for the current binary use case, it has several architectural drawbacks:
- The function depended directly on CLI parsing.
- It could not be reused programmatically without CLI context.
- CLI parsing was executed twice.

`wait_for_readiness` is business logic and should not depend on how configuration is obtained.

What Changed:
- Added `timeout`: Duration parameter to `wait_for_readiness`
- Removed internal `CliArgs::parse()` call
- Passed `Duration::from_secs(args.timeout`) from `main`
- Updated `timeout` error message to use `timeout.as_secs()`

***

Fixed syntactic errors: `transacion` > `transaction` in [`main.rs`](https://github.com/S0nee/rpc-tester/blob/main/crates/rpc-tester-cli/src/main.rs) and in the root [`README`](https://github.com/S0nee/rpc-tester/blob/main/README.md).

***

Notes:
**These changes are primarily architectural improvements and are not critical fixes.**