### PR TITLE
Fix doc-comment in `RpcTester::fetch_block` to reference `rpc2` instead of nonexistent `truth`

### DIFF
--- a/crates/rpc-tester/src/tester.rs
+++ b/crates/rpc-tester/src/tester.rs
@@ -201,7 +201,7 @@ where
         Ok(())
     }
 
-    /// Fetches block and block identifiers from `self.truth`.
+    /// Fetches block and block identifiers from `self.rpc2`.
     async fn fetch_block(
         &self,
         block_number: u64,


### PR DESCRIPTION
PR Description (English)

## Problem:
In the RpcTester::fetch_block method, the documentation comment states that blocks are retrieved from self.truth. However, self.rpc2 is actually used. This appears to serve as the reference RPC node for block data, although it’s not formally documented everywhere. This discrepancy may be misleading.

## Solution:
Updated the doc-comment to accurately reflect the implementation:
```rust
/// Fetches block and block identifiers from `self.rpc2`.
```
## Changes:

- Only the comment is modified; the function’s logic remains unchanged. 
- Improves readability and correctness of the documentation.