### PR TITLE
feat: add historical block sampling mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,10 @@ Options:
   -h, --help                     Print help
 ```
 
-In addition to the `[head - num_blocks + 1, head]` tip range, every run samples log-spaced
-historical blocks backwards from the tip (`head-128`, `head-1024`, `head-10000`, `head-100000`,
-`head-1000000`, capped at genesis). These exercise cold history such as static files and pruned
-tables that near-tip blocks do not.
+In addition to the `[head - num_blocks + 1, head]` tip range, every run randomly samples
+historical blocks: `num_blocks` picks from the near-history window `[head-128, head-8]`, which
+crosses the boundary where lazily persisting clients move blocks from memory to storage, plus one
+pick per log-spaced deep-history stratum (offsets up to 1024, 10000, 100000 and 1000000, capped
+at genesis). Deep samples exercise cold history such as static files and pruned tables that
+near-tip blocks do not, and randomness means repeated runs accumulate coverage instead of
+re-testing the same blocks. The sampled set is logged at startup.

--- a/README.md
+++ b/README.md
@@ -8,14 +8,17 @@ Usage: rpc-tester-cli [OPTIONS] --rpc1 <RPC_URL1> --rpc2 <RPC_URL2>
 Options:
       --rpc1 <RPC_URL1>          RPC URL 1
       --rpc2 <RPC_URL2>          RPC URL 2
-      --num-blocks <NUM_BLOCKS>  Number of blocks to test from the tip [default: 32]
+      --num-blocks <NUM_BLOCKS>  Number of blocks to test from the tip [default: 8]
       --use-reth                 Whether to query reth namespace
       --use-tracing              Whether to query tracing methods
       --use-all-txes             Whether to query every transacion from a block or just the first
       --skip-extended-eth        Skip extended eth methods not supported by all clients (e.g., `eth_getRawTransactionByBlockNumberAndIndex`)
       --timeout <TIMEOUT>        Maximum time to wait for syncing in seconds [default: 300]
       --rate-limit <RATE_LIMIT>  Maximum requests per second (rate limit)
-      --historical               Additionally test log-spaced historical blocks sampled backwards from the tip (head-128, head-1024, head-10000, head-100000, head-1000000)
-      --blocks <BLOCKS>          Additional pinned block numbers to test, comma separated
   -h, --help                     Print help
 ```
+
+In addition to the `[head - num_blocks + 1, head]` tip range, every run samples log-spaced
+historical blocks backwards from the tip (`head-128`, `head-1024`, `head-10000`, `head-100000`,
+`head-1000000`, capped at genesis). These exercise cold history such as static files and pruned
+tables that near-tip blocks do not.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,10 @@ Options:
       --use-reth                 Whether to query reth namespace
       --use-tracing              Whether to query tracing methods
       --use-all-txes             Whether to query every transacion from a block or just the first
-      --rate-limit <RATE_LIMIT>  Maximum requests per second (rate limit)
+      --skip-extended-eth        Skip extended eth methods not supported by all clients (e.g., `eth_getRawTransactionByBlockNumberAndIndex`)
       --timeout <TIMEOUT>        Maximum time to wait for syncing in seconds [default: 300]
+      --rate-limit <RATE_LIMIT>  Maximum requests per second (rate limit)
+      --historical               Additionally test log-spaced historical blocks sampled backwards from the tip (head-128, head-1024, head-10000, head-100000, head-1000000)
+      --blocks <BLOCKS>          Additional pinned block numbers to test, comma separated
   -h, --help                     Print help
 ```

--- a/crates/rpc-tester-cli/src/main.rs
+++ b/crates/rpc-tester-cli/src/main.rs
@@ -3,7 +3,7 @@
 use alloy_provider::{network::AnyNetwork, Provider, ProviderBuilder};
 use alloy_rpc_types::SyncStatus;
 use clap::Parser;
-use rpc_tester::RpcTester;
+use rpc_tester::{historical_blocks, RpcTester};
 use std::{
     ops::RangeInclusive,
     time::{Duration, Instant},
@@ -52,6 +52,20 @@ pub struct CliArgs {
     /// If not provided, no rate limiting is applied.
     #[arg(long, value_name = "RATE_LIMIT")]
     pub rate_limit: Option<u32>,
+
+    /// Additionally test log-spaced historical blocks sampled backwards from the tip
+    /// (head-128, head-1024, head-10000, head-100000, head-1000000).
+    ///
+    /// This exercises cold history (static files, pruned tables) that near-tip blocks do not.
+    #[arg(long)]
+    pub historical: bool,
+
+    /// Additional pinned block numbers to test, comma separated.
+    ///
+    /// Useful for chain-specific edge cases such as fork transition blocks or blocks with rare
+    /// transaction types.
+    #[arg(long, value_name = "BLOCKS", value_delimiter = ',')]
+    pub blocks: Vec<u64>,
 }
 
 #[tokio::main]
@@ -71,15 +85,29 @@ async fn main() -> eyre::Result<()> {
 
     let block_range = wait_for_readiness(&rpc1, &rpc2, args.num_blocks).await?;
 
-    RpcTester::builder(rpc1, rpc2)
+    let tester = RpcTester::builder(rpc1, rpc2)
         .with_tracing(args.use_tracing)
         .with_reth(args.use_reth)
         .with_all_txes(args.use_all_txes)
         .skip_extended_eth(args.skip_extended_eth)
         .with_rate_limit(args.rate_limit)
-        .build()
-        .run(block_range)
-        .await
+        .build();
+
+    let mut extra_blocks = args.blocks;
+    if args.historical {
+        extra_blocks.extend(historical_blocks(*block_range.end()));
+    }
+    extra_blocks.sort_unstable();
+    extra_blocks.dedup();
+    extra_blocks.retain(|block| !block_range.contains(block));
+
+    // Run both suites to completion before failing so a diff in one does not hide the other.
+    let range_result = tester.run(block_range).await;
+    if !extra_blocks.is_empty() {
+        info!(blocks = ?extra_blocks, "testing historical blocks");
+        tester.run_blocks(extra_blocks).await?;
+    }
+    range_result
 }
 
 /// Waits until rpc1 is synced to the tip and returns a valid block range to test against rpc2.

--- a/crates/rpc-tester-cli/src/main.rs
+++ b/crates/rpc-tester-cli/src/main.rs
@@ -79,9 +79,10 @@ async fn main() -> eyre::Result<()> {
         .with_rate_limit(args.rate_limit)
         .build();
 
-    // Log-spaced historical samples reaching beyond the tip range. These exercise cold history
-    // (static files, pruned tables) that near-tip blocks do not.
-    let mut historical = historical_blocks(*block_range.end());
+    // Random historical samples reaching beyond the tip range: near-history picks crossing the
+    // persistence boundary of lazily persisting clients, plus one pick per deep-history stratum
+    // exercising cold storage. Randomness accumulates coverage across repeated runs.
+    let mut historical = historical_blocks(*block_range.end(), args.num_blocks as usize);
     historical.retain(|block| !block_range.contains(block));
 
     // Run both suites to completion before failing so a diff in one does not hide the other.

--- a/crates/rpc-tester-cli/src/main.rs
+++ b/crates/rpc-tester-cli/src/main.rs
@@ -24,7 +24,7 @@ pub struct CliArgs {
     pub rpc2: Url,
 
     /// Number of blocks to test from the tip.
-    #[arg(long, value_name = "NUM_BLOCKS", default_value = "32")]
+    #[arg(long, value_name = "NUM_BLOCKS", default_value = "8")]
     pub num_blocks: u64,
 
     /// Whether to query reth namespace
@@ -52,20 +52,6 @@ pub struct CliArgs {
     /// If not provided, no rate limiting is applied.
     #[arg(long, value_name = "RATE_LIMIT")]
     pub rate_limit: Option<u32>,
-
-    /// Additionally test log-spaced historical blocks sampled backwards from the tip
-    /// (head-128, head-1024, head-10000, head-100000, head-1000000).
-    ///
-    /// This exercises cold history (static files, pruned tables) that near-tip blocks do not.
-    #[arg(long)]
-    pub historical: bool,
-
-    /// Additional pinned block numbers to test, comma separated.
-    ///
-    /// Useful for chain-specific edge cases such as fork transition blocks or blocks with rare
-    /// transaction types.
-    #[arg(long, value_name = "BLOCKS", value_delimiter = ',')]
-    pub blocks: Vec<u64>,
 }
 
 #[tokio::main]
@@ -93,19 +79,16 @@ async fn main() -> eyre::Result<()> {
         .with_rate_limit(args.rate_limit)
         .build();
 
-    let mut extra_blocks = args.blocks;
-    if args.historical {
-        extra_blocks.extend(historical_blocks(*block_range.end()));
-    }
-    extra_blocks.sort_unstable();
-    extra_blocks.dedup();
-    extra_blocks.retain(|block| !block_range.contains(block));
+    // Log-spaced historical samples reaching beyond the tip range. These exercise cold history
+    // (static files, pruned tables) that near-tip blocks do not.
+    let mut historical = historical_blocks(*block_range.end());
+    historical.retain(|block| !block_range.contains(block));
 
     // Run both suites to completion before failing so a diff in one does not hide the other.
     let range_result = tester.run(block_range).await;
-    if !extra_blocks.is_empty() {
-        info!(blocks = ?extra_blocks, "testing historical blocks");
-        tester.run_blocks(extra_blocks).await?;
+    if !historical.is_empty() {
+        info!(blocks = ?historical, "testing historical blocks");
+        tester.run_blocks(historical).await?;
     }
     range_result
 }

--- a/crates/rpc-tester/src/lib.rs
+++ b/crates/rpc-tester/src/lib.rs
@@ -7,7 +7,9 @@ mod tester;
 pub use tester::RpcTester;
 mod report;
 mod sampling;
-pub use sampling::{historical_blocks, HISTORICAL_OFFSETS};
+pub use sampling::{
+    historical_blocks, DEEP_STRATA, NEAR_WINDOW_MAX_OFFSET, NEAR_WINDOW_MIN_OFFSET,
+};
 
 /// Equality rpc test error
 enum TestError {

--- a/crates/rpc-tester/src/lib.rs
+++ b/crates/rpc-tester/src/lib.rs
@@ -6,6 +6,8 @@ pub mod get_logs;
 mod tester;
 pub use tester::RpcTester;
 mod report;
+mod sampling;
+pub use sampling::{historical_blocks, HISTORICAL_OFFSETS};
 
 /// Equality rpc test error
 enum TestError {

--- a/crates/rpc-tester/src/sampling.rs
+++ b/crates/rpc-tester/src/sampling.rs
@@ -1,0 +1,44 @@
+//! Helpers for sampling historical blocks.
+
+use alloy_primitives::BlockNumber;
+
+/// Log-spaced offsets from the chain head used by [`historical_blocks`].
+///
+/// Recent blocks are typically served from in-memory or hot storage, while deeper blocks exercise
+/// cold history such as static files or pruned tables. Log-spacing keeps the number of sampled
+/// blocks small while still crossing those boundaries.
+pub const HISTORICAL_OFFSETS: [u64; 5] = [128, 1_024, 10_000, 100_000, 1_000_000];
+
+/// Returns log-spaced historical block numbers sampled backwards from `head`.
+///
+/// Applies every offset in [`HISTORICAL_OFFSETS`], skipping offsets that would reach past genesis.
+/// The result is sorted ascending and deduplicated.
+pub fn historical_blocks(head: BlockNumber) -> Vec<BlockNumber> {
+    let mut blocks: Vec<BlockNumber> =
+        HISTORICAL_OFFSETS.iter().filter_map(|offset| head.checked_sub(*offset)).collect();
+    blocks.sort_unstable();
+    blocks.dedup();
+    blocks
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn samples_all_offsets_on_deep_chain() {
+        let head = 10_000_000;
+        assert_eq!(
+            historical_blocks(head),
+            vec![9_000_000, 9_900_000, 9_990_000, 9_998_976, 9_999_872]
+        );
+    }
+
+    #[test]
+    fn skips_offsets_past_genesis() {
+        assert_eq!(historical_blocks(10_000), vec![0, 8_976, 9_872]);
+        assert_eq!(historical_blocks(128), vec![0]);
+        assert_eq!(historical_blocks(127), Vec::<BlockNumber>::new());
+        assert_eq!(historical_blocks(0), Vec::<BlockNumber>::new());
+    }
+}

--- a/crates/rpc-tester/src/sampling.rs
+++ b/crates/rpc-tester/src/sampling.rs
@@ -1,24 +1,86 @@
 //! Helpers for sampling historical blocks.
 
 use alloy_primitives::BlockNumber;
+use std::time::{SystemTime, UNIX_EPOCH};
 
-/// Log-spaced offsets from the chain head used by [`historical_blocks`].
-///
-/// Recent blocks are typically served from in-memory or hot storage, while deeper blocks exercise
-/// cold history such as static files or pruned tables. Log-spacing keeps the number of sampled
-/// blocks small while still crossing those boundaries.
-pub const HISTORICAL_OFFSETS: [u64; 5] = [128, 1_024, 10_000, 100_000, 1_000_000];
+/// Shallowest offset of the near-history window, exclusive of the tip range.
+pub const NEAR_WINDOW_MIN_OFFSET: u64 = 8;
 
-/// Returns log-spaced historical block numbers sampled backwards from `head`.
+/// Deepest offset of the near-history window.
 ///
-/// Applies every offset in [`HISTORICAL_OFFSETS`], skipping offsets that would reach past genesis.
-/// The result is sorted ascending and deduplicated.
-pub fn historical_blocks(head: BlockNumber) -> Vec<BlockNumber> {
-    let mut blocks: Vec<BlockNumber> =
-        HISTORICAL_OFFSETS.iter().filter_map(|offset| head.checked_sub(*offset)).collect();
+/// Blocks in `[head - NEAR_WINDOW_MAX_OFFSET, head - NEAR_WINDOW_MIN_OFFSET]` span the region
+/// where clients with lazy persistence cross from in-memory state to persisted storage, so
+/// random samples from this window exercise both sides of that boundary.
+pub const NEAR_WINDOW_MAX_OFFSET: u64 = 128;
+
+/// Deep-history offset strata. One block is sampled uniformly from each `(start, end]` offset
+/// range, keeping depth coverage log-spread without fixed blind spots between samples.
+pub const DEEP_STRATA: [(u64, u64); 4] =
+    [(128, 1_024), (1_024, 10_000), (10_000, 100_000), (100_000, 1_000_000)];
+
+/// Returns randomly sampled historical block numbers below `head`.
+///
+/// Samples `near_samples` blocks uniformly from the near-history window (see
+/// [`NEAR_WINDOW_MAX_OFFSET`]) plus one block per [`DEEP_STRATA`] stratum, skipping any range
+/// that reaches past genesis. The result is sorted ascending and deduplicated, so it may contain
+/// fewer entries than requested. Randomness means repeated runs accumulate coverage instead of
+/// re-testing the same blocks; the caller should log the sampled set.
+pub fn historical_blocks(head: BlockNumber, near_samples: usize) -> Vec<BlockNumber> {
+    sample_blocks(head, near_samples, &mut Rng::from_entropy())
+}
+
+/// Deterministic core of [`historical_blocks`].
+fn sample_blocks(head: BlockNumber, near_samples: usize, rng: &mut Rng) -> Vec<BlockNumber> {
+    let mut blocks = Vec::new();
+
+    if head > NEAR_WINDOW_MIN_OFFSET {
+        let max_offset = NEAR_WINDOW_MAX_OFFSET.min(head);
+        for _ in 0..near_samples {
+            blocks.push(head - rng.sample_range(NEAR_WINDOW_MIN_OFFSET, max_offset));
+        }
+    }
+
+    for (start, end) in DEEP_STRATA {
+        if head <= start {
+            break;
+        }
+        let end = end.min(head);
+        blocks.push(head - rng.sample_range(start + 1, end));
+    }
+
     blocks.sort_unstable();
     blocks.dedup();
     blocks
+}
+
+/// Minimal xorshift64* generator.
+///
+/// The sampling here has no quality or security requirements, so this avoids pulling in a rng
+/// crate.
+struct Rng(u64);
+
+impl Rng {
+    /// Seeds the generator from the system clock.
+    fn from_entropy() -> Self {
+        let nanos = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().subsec_nanos();
+        let secs = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_secs();
+        // Never zero, which would make xorshift degenerate.
+        Self((u64::from(nanos) << 32 | secs & 0xffff_ffff) | 1)
+    }
+
+    fn next(&mut self) -> u64 {
+        let mut x = self.0;
+        x ^= x << 13;
+        x ^= x >> 7;
+        x ^= x << 17;
+        self.0 = x;
+        x.wrapping_mul(0x2545_F491_4F6C_DD1D)
+    }
+
+    /// Returns a value in `[min, max]`. The modulo bias is irrelevant at these range sizes.
+    fn sample_range(&mut self, min: u64, max: u64) -> u64 {
+        min + self.next() % (max - min + 1)
+    }
 }
 
 #[cfg(test)]
@@ -26,19 +88,53 @@ mod tests {
     use super::*;
 
     #[test]
-    fn samples_all_offsets_on_deep_chain() {
+    fn samples_stay_in_their_ranges() {
         let head = 10_000_000;
+        let blocks = sample_blocks(head, 8, &mut Rng(42));
+
+        let near: Vec<_> = blocks
+            .iter()
+            .filter(|b| {
+                **b >= head - NEAR_WINDOW_MAX_OFFSET && **b <= head - NEAR_WINDOW_MIN_OFFSET
+            })
+            .collect();
+        assert!(!near.is_empty() && near.len() <= 8);
+
+        for (start, end) in DEEP_STRATA {
+            let in_stratum =
+                blocks.iter().filter(|b| **b >= head - end && **b < head - start).count();
+            assert_eq!(in_stratum, 1, "expected exactly one sample in stratum ({start}, {end}]");
+        }
+
+        assert!(blocks.windows(2).all(|w| w[0] < w[1]), "sorted and deduplicated");
+    }
+
+    #[test]
+    fn deterministic_for_same_seed() {
         assert_eq!(
-            historical_blocks(head),
-            vec![9_000_000, 9_900_000, 9_990_000, 9_998_976, 9_999_872]
+            sample_blocks(10_000_000, 8, &mut Rng(7)),
+            sample_blocks(10_000_000, 8, &mut Rng(7))
+        );
+        assert_ne!(
+            sample_blocks(10_000_000, 8, &mut Rng(7)),
+            sample_blocks(10_000_000, 8, &mut Rng(8))
         );
     }
 
     #[test]
-    fn skips_offsets_past_genesis() {
-        assert_eq!(historical_blocks(10_000), vec![0, 8_976, 9_872]);
-        assert_eq!(historical_blocks(128), vec![0]);
-        assert_eq!(historical_blocks(127), Vec::<BlockNumber>::new());
-        assert_eq!(historical_blocks(0), Vec::<BlockNumber>::new());
+    fn young_chains_clamp_to_genesis() {
+        // Head below the near window: nothing to sample.
+        assert!(sample_blocks(8, 8, &mut Rng(1)).is_empty());
+        assert!(sample_blocks(0, 8, &mut Rng(1)).is_empty());
+
+        // Head inside the near window: samples stay within [0, head - min offset].
+        let blocks = sample_blocks(100, 8, &mut Rng(1));
+        assert!(!blocks.is_empty());
+        assert!(blocks.iter().all(|b| *b <= 100 - NEAR_WINDOW_MIN_OFFSET));
+
+        // Head inside a deep stratum: the partial stratum is still sampled, deeper ones skipped.
+        let blocks = sample_blocks(2_000, 0, &mut Rng(1));
+        assert_eq!(blocks.len(), 2);
+        assert!(blocks.iter().all(|b| *b < 2_000 - 128));
     }
 }

--- a/crates/rpc-tester/src/tester.rs
+++ b/crates/rpc-tester/src/tester.rs
@@ -71,11 +71,23 @@ where
         Ok(())
     }
 
+    /// Verifies RPC calls applicable to single blocks for each of the given blocks.
+    ///
+    /// Unlike [`Self::run`], this does not run block range tests, so the blocks do not need to be
+    /// contiguous. This is intended for sampled historical blocks, see
+    /// [`historical_blocks`](crate::historical_blocks).
+    pub async fn run_blocks(&self, blocks: impl IntoIterator<Item = BlockNumber>) -> Result<()> {
+        self.test_per_block(blocks).await
+    }
+
     /// Verifies RPC calls applicable to single blocks.
-    async fn test_per_block(&self, block_range: RangeInclusive<u64>) -> Result<(), eyre::Error> {
+    async fn test_per_block(
+        &self,
+        blocks: impl IntoIterator<Item = BlockNumber>,
+    ) -> Result<(), eyre::Error> {
         let mut results = BlockTestResults::new();
 
-        for block_number in block_range {
+        for block_number in blocks {
             info!(block_number, "testing rpc");
 
             let mut tests = vec![];
@@ -210,8 +222,12 @@ where
             .rpc2
             .get_block_by_number(block_number.into(), true.into())
             .await?
-            .expect("should have block from range");
-        assert_eq!(block.header.number, block_number);
+            .ok_or_else(|| eyre::eyre!("block {block_number} not found on rpc2"))?;
+        eyre::ensure!(
+            block.header.number == block_number,
+            "rpc2 returned block {} for requested block {block_number}",
+            block.header.number
+        );
         let block_hash = block.header.hash;
         let block_tag = BlockNumberOrTag::Number(block_number);
         let block_id = BlockId::Number(block_tag);


### PR DESCRIPTION
Everything the tester covers today runs against the last few blocks from tip, which are served from hot storage on both nodes. Bugs in static files, pruned history, and tx/receipt index rebuilding are invisible to that, and clients that persist lazily (reth keeps recent blocks in an in-memory overlay and persists later) never get their persisted-read path tested at all.

Every run now samples historical blocks in addition to the `[head - num_blocks + 1, head]` tip range, with no flag needed. Sampling is random rather than fixed: `num_blocks` picks from the near-history window `[head-128, head-8]`, which crosses the boundary where lazily persisting clients move blocks from memory to storage, plus one pick per log-spaced deep-history stratum (offsets up to 1024, 10000, 100000 and 1000000, capped at genesis). Fixed offsets would test the same blocks on every run with their data warm in caches; random picks accumulate coverage across repeated CI runs and have no permanent blind spots. The sampled set is logged at startup and failures name their block number, so runs stay diagnosable. Randomness comes from a dependency-free xorshift seeded from the clock, with the deterministic core unit-tested against fixed seeds.

`--num-blocks` controls both the tip range and the near-history sample count, and its default drops from 32 to 8 since the historical samples now cover depth. The tester exposes `run_blocks` for testing non-contiguous block sets, and `fetch_block` returns a proper error instead of panicking when a requested block does not exist.

Part of #29