### PR TITLE
test: add same-node self-test with anvil and test CI

### DIFF
--- a/.github/workflows/live-smoke.yml
+++ b/.github/workflows/live-smoke.yml
@@ -1,0 +1,39 @@
+name: live-smoke
+
+# Smoke test against a live endpoint used as both rpc1 and rpc2: comparing a node against itself
+# must always succeed, so a failure indicates a bug in the tester (or an endpoint outage).
+
+on:
+  workflow_dispatch:
+    inputs:
+      rpc:
+        description: RPC endpoint to smoke test (used as both rpc1 and rpc2)
+        required: false
+        default: https://ethereum.reth.rs/rpc
+  schedule:
+    # Weekly on Monday morning.
+    - cron: "0 6 * * 1"
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  same-node:
+    name: same-node smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+      - name: Run tester against a single live node
+        env:
+          RPC: ${{ inputs.rpc || 'https://ethereum.reth.rs/rpc' }}
+        run: >
+          cargo run --release -p rpc-tester-cli --
+          --rpc1 "$RPC"
+          --rpc2 "$RPC"
+          --num-blocks 3
+          --rate-limit 20

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,25 @@
+name: test
+
+on:
+  pull_request:
+  merge_group:
+  push:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+      # Installs anvil, used by the same-node self-test.
+      - uses: foundry-rs/foundry-toolchain@v1
+      - run: cargo test --workspace --all-features --locked

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,6 +121,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-genesis"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cded3a2d4bd7173f696458c5d4c98c18a628dfcc9f194385e80a486e412e2e0"
+dependencies = [
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-serde",
+ "alloy-trie",
+ "serde",
+]
+
+[[package]]
 name = "alloy-json-rpc"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -170,6 +183,26 @@ dependencies = [
  "alloy-primitives",
  "alloy-serde",
  "serde",
+]
+
+[[package]]
+name = "alloy-node-bindings"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81a3906afb50446392eb798dae4b918ba4ffcca47542efda7215776ddc8b5037"
+dependencies = [
+ "alloy-genesis",
+ "alloy-network",
+ "alloy-primitives",
+ "alloy-signer",
+ "alloy-signer-local",
+ "k256",
+ "rand",
+ "serde_json",
+ "tempfile",
+ "thiserror",
+ "tracing",
+ "url",
 ]
 
 [[package]]
@@ -392,6 +425,22 @@ dependencies = [
  "either",
  "elliptic-curve",
  "k256",
+ "thiserror",
+]
+
+[[package]]
+name = "alloy-signer-local"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe8f78cd6b7501c7e813a1eb4a087b72d23af51f5bb66d4e948dc840bdd207d8"
+dependencies = [
+ "alloy-consensus",
+ "alloy-network",
+ "alloy-primitives",
+ "alloy-signer",
+ "async-trait",
+ "k256",
+ "rand",
  "thiserror",
 ]
 
@@ -2502,6 +2551,7 @@ name = "rpc-tester"
 version = "0.1.0"
 dependencies = [
  "alloy-json-rpc",
+ "alloy-node-bindings",
  "alloy-primitives",
  "alloy-provider",
  "alloy-rpc-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,6 +113,7 @@ alloy-primitives = "0.8.21"
 alloy-rpc-types = "0.11.1"
 alloy-rpc-types-trace = "0.11.1"
 alloy-provider = "0.11.1"
+alloy-node-bindings = "0.11.1"
 
 assert-json-diff = "2.0.2"
 clap = "4"

--- a/crates/rpc-tester-cli/src/main.rs
+++ b/crates/rpc-tester-cli/src/main.rs
@@ -69,7 +69,9 @@ async fn main() -> eyre::Result<()> {
         .network::<AnyNetwork>()
         .on_http(args.rpc2);
 
-    let block_range = wait_for_readiness(&rpc1, &rpc2, args.num_blocks).await?;
+    let block_range =
+        wait_for_readiness(&rpc1, &rpc2, args.num_blocks, Duration::from_secs(args.timeout))
+            .await?;
 
     let tester = RpcTester::builder(rpc1, rpc2)
         .with_tracing(args.use_tracing)
@@ -99,18 +101,14 @@ pub async fn wait_for_readiness<P: Provider<AnyNetwork>>(
     rpc1: &P,
     rpc2: &P,
     block_size_range: u64,
+    timeout: Duration,
 ) -> eyre::Result<RangeInclusive<u64>> {
-    let args = CliArgs::parse();
     let start_time = Instant::now();
-    let timeout = Duration::from_secs(args.timeout);
 
     // Waits until it's done syncing
     while let SyncStatus::Info(sync_info) = rpc1.syncing().await? {
         if start_time.elapsed() > timeout {
-            return Err(eyre::eyre!(
-                "Timeout waiting for rpc1 to sync after {} seconds",
-                args.timeout
-            ));
+            return Err(eyre::eyre!("Timeout waiting for rpc1 to sync after {timeout:?}"));
         }
         info!(?sync_info, "rpc1 still syncing");
         tokio::time::sleep(Duration::from_secs(5)).await;
@@ -123,7 +121,8 @@ pub async fn wait_for_readiness<P: Provider<AnyNetwork>>(
 
         if tip1 >= tip2 || tip2 - tip1 <= 5 {
             let common = tip1.min(tip2);
-            let range = common - (block_size_range - 1)..=common;
+            // Saturate so young chains with fewer blocks than the requested range still work.
+            let range = common.saturating_sub(block_size_range.saturating_sub(1))..=common;
             info!(?range, "testing block range");
             return Ok(range);
         }

--- a/crates/rpc-tester/Cargo.toml
+++ b/crates/rpc-tester/Cargo.toml
@@ -22,3 +22,7 @@ serde = { workspace = true, default-features = false }
 serde_json.workspace = true
 tokio = { workspace = true, default-features = false }
 tracing.workspace = true
+
+[dev-dependencies]
+alloy-node-bindings.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }

--- a/crates/rpc-tester/tests/same_node.rs
+++ b/crates/rpc-tester/tests/same_node.rs
@@ -1,0 +1,82 @@
+//! Self-test running the tester against a single anvil node.
+//!
+//! Pointing `rpc1` and `rpc2` at the same node must always succeed, so this catches bugs in the
+//! tester itself (request construction, comparison, pagination, reporting) without needing two
+//! live nodes. Requires `anvil` to be installed.
+
+use alloy_node_bindings::{Anvil, AnvilInstance};
+use alloy_primitives::B256;
+use alloy_provider::{network::AnyNetwork, Provider, ProviderBuilder};
+use rpc_tester::RpcTester;
+use serde_json::json;
+use std::time::Duration;
+
+/// First two anvil dev accounts.
+const ALICE: &str = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
+const BOB: &str = "0x70997970C51812dc3A010C7d01b50e0d17dc79C8";
+
+/// Init code that emits a `LOG1` with a fixed topic and deploys an empty contract:
+/// `PUSH32 topic PUSH1 0 PUSH1 0 LOG1 STOP`.
+///
+/// This gives us a receipt with a log so the receipt-derived `eth_getLogs` filters are exercised.
+const LOG_EMITTER_INIT_CODE: &str =
+    "0x7faaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa60006000a100";
+
+fn provider(anvil: &AnvilInstance) -> impl Provider<AnyNetwork> + Clone {
+    ProviderBuilder::new()
+        .disable_recommended_fillers()
+        .network::<AnyNetwork>()
+        .on_http(anvil.endpoint_url())
+}
+
+/// Sends a transaction from an unlocked dev account and waits until it is mined.
+async fn send_and_mine<P: Provider<AnyNetwork>>(provider: &P, tx: serde_json::Value) {
+    let hash: B256 =
+        provider.raw_request("eth_sendTransaction".into(), [tx]).await.expect("send tx");
+    for _ in 0..50 {
+        if provider.get_transaction_receipt(hash).await.expect("get receipt").is_some() {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    panic!("transaction {hash} was not mined");
+}
+
+/// Populates the chain with a value transfer, a log-emitting contract deployment, and an empty
+/// block, and returns the chain head.
+async fn populate_chain<P: Provider<AnyNetwork>>(provider: &P) -> u64 {
+    send_and_mine(provider, json!({ "from": ALICE, "to": BOB, "value": "0x2540be400" })).await;
+    send_and_mine(provider, json!({ "from": ALICE, "data": LOG_EMITTER_INIT_CODE })).await;
+    let _: serde_json::Value = provider.raw_request("evm_mine".into(), ()).await.expect("evm_mine");
+
+    let head = provider.get_block_number().await.expect("get head");
+    assert!(head >= 3, "expected at least 3 blocks, got {head}");
+    head
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn same_node_passes() {
+    let anvil = Anvil::new().try_spawn().expect("anvil must be installed");
+    let head = populate_chain(&provider(&anvil)).await;
+
+    let tester = RpcTester::builder(provider(&anvil), provider(&anvil))
+        .with_tracing(true)
+        .with_all_txes(true)
+        .build();
+
+    // Full suite over the whole chain, including the empty genesis block.
+    tester.run(0..=head).await.expect("same node must be a superset of itself");
+
+    // Sampled non-contiguous blocks, as used by historical mode.
+    tester.run_blocks([0, head]).await.expect("same node must be a superset of itself");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn missing_block_errors() {
+    let anvil = Anvil::new().try_spawn().expect("anvil must be installed");
+    let head = populate_chain(&provider(&anvil)).await;
+
+    let tester = RpcTester::builder(provider(&anvil), provider(&anvil)).build();
+    let result = tester.run_blocks([head + 1000]).await;
+    assert!(result.is_err(), "requesting a block beyond the tip must error, not panic");
+}


### PR DESCRIPTION
The tester had no way to test itself: every change had to be verified manually against live nodes. This adds a self-test based on the property that comparing a node against itself must always succeed, so any failure is a bug in the tester (request construction, comparison, pagination, reporting) rather than a node diff.

The integration test spawns an anvil node, populates it with a value transfer, a log-emitting contract deployment, and an empty block, then runs the full suite (tracing and all-txes enabled, anvil supports every queried method) over the whole chain plus the non-contiguous `run_blocks` path. A second test asserts that requesting a block beyond the tip errors instead of panicking. A new test workflow runs these in CI with anvil installed via foundry-toolchain, and a weekly/manually dispatchable live-smoke workflow runs the CLI against https://ethereum.reth.rs/rpc as both rpc1 and rpc2, which includes the default historical sampling.

Also fixes two `wait_for_readiness` issues that surface when running against a fresh anvil chain: the range start underflowed when the chain is shorter than `--num-blocks`, and the function re-parsed `CliArgs` internally instead of taking the timeout as a parameter.

Stacked on #30. Part of #29