### PR TITLE
feat: add state method coverage

### DIFF
--- a/.github/workflows/live-smoke.yml
+++ b/.github/workflows/live-smoke.yml
@@ -1,0 +1,39 @@
+name: live-smoke
+
+# Smoke test against a live endpoint used as both rpc1 and rpc2: comparing a node against itself
+# must always succeed, so a failure indicates a bug in the tester (or an endpoint outage).
+
+on:
+  workflow_dispatch:
+    inputs:
+      rpc:
+        description: RPC endpoint to smoke test (used as both rpc1 and rpc2)
+        required: false
+        default: https://ethereum.reth.rs/rpc
+  schedule:
+    # Weekly on Monday morning.
+    - cron: "0 6 * * 1"
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  same-node:
+    name: same-node smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+      - name: Run tester against a single live node
+        env:
+          RPC: ${{ inputs.rpc || 'https://ethereum.reth.rs/rpc' }}
+        run: >
+          cargo run --release -p rpc-tester-cli --
+          --rpc1 "$RPC"
+          --rpc2 "$RPC"
+          --num-blocks 3
+          --rate-limit 20

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,25 @@
+name: test
+
+on:
+  pull_request:
+  merge_group:
+  push:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+      # Installs anvil, used by the same-node self-test.
+      - uses: foundry-rs/foundry-toolchain@v1
+      - run: cargo test --workspace --all-features --locked

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,6 +121,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-genesis"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cded3a2d4bd7173f696458c5d4c98c18a628dfcc9f194385e80a486e412e2e0"
+dependencies = [
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-serde",
+ "alloy-trie",
+ "serde",
+]
+
+[[package]]
 name = "alloy-json-rpc"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -170,6 +183,26 @@ dependencies = [
  "alloy-primitives",
  "alloy-serde",
  "serde",
+]
+
+[[package]]
+name = "alloy-node-bindings"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81a3906afb50446392eb798dae4b918ba4ffcca47542efda7215776ddc8b5037"
+dependencies = [
+ "alloy-genesis",
+ "alloy-network",
+ "alloy-primitives",
+ "alloy-signer",
+ "alloy-signer-local",
+ "k256",
+ "rand",
+ "serde_json",
+ "tempfile",
+ "thiserror",
+ "tracing",
+ "url",
 ]
 
 [[package]]
@@ -392,6 +425,22 @@ dependencies = [
  "either",
  "elliptic-curve",
  "k256",
+ "thiserror",
+]
+
+[[package]]
+name = "alloy-signer-local"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe8f78cd6b7501c7e813a1eb4a087b72d23af51f5bb66d4e948dc840bdd207d8"
+dependencies = [
+ "alloy-consensus",
+ "alloy-network",
+ "alloy-primitives",
+ "alloy-signer",
+ "async-trait",
+ "k256",
+ "rand",
  "thiserror",
 ]
 
@@ -2502,6 +2551,7 @@ name = "rpc-tester"
 version = "0.1.0"
 dependencies = [
  "alloy-json-rpc",
+ "alloy-node-bindings",
  "alloy-primitives",
  "alloy-provider",
  "alloy-rpc-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,6 +113,7 @@ alloy-primitives = "0.8.21"
 alloy-rpc-types = "0.11.1"
 alloy-rpc-types-trace = "0.11.1"
 alloy-provider = "0.11.1"
+alloy-node-bindings = "0.11.1"
 
 assert-json-diff = "2.0.2"
 clap = "4"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,10 @@ Options:
   -h, --help                     Print help
 ```
 
-In addition to the `[head - num_blocks + 1, head]` tip range, every run samples log-spaced
-historical blocks backwards from the tip (`head-128`, `head-1024`, `head-10000`, `head-100000`,
-`head-1000000`, capped at genesis). These exercise cold history such as static files and pruned
-tables that near-tip blocks do not.
+In addition to the `[head - num_blocks + 1, head]` tip range, every run randomly samples
+historical blocks: `num_blocks` picks from the near-history window `[head-128, head-8]`, which
+crosses the boundary where lazily persisting clients move blocks from memory to storage, plus one
+pick per log-spaced deep-history stratum (offsets up to 1024, 10000, 100000 and 1000000, capped
+at genesis). Deep samples exercise cold history such as static files and pruned tables that
+near-tip blocks do not, and randomness means repeated runs accumulate coverage instead of
+re-testing the same blocks. The sampled set is logged at startup.

--- a/README.md
+++ b/README.md
@@ -8,14 +8,17 @@ Usage: rpc-tester-cli [OPTIONS] --rpc1 <RPC_URL1> --rpc2 <RPC_URL2>
 Options:
       --rpc1 <RPC_URL1>          RPC URL 1
       --rpc2 <RPC_URL2>          RPC URL 2
-      --num-blocks <NUM_BLOCKS>  Number of blocks to test from the tip [default: 32]
+      --num-blocks <NUM_BLOCKS>  Number of blocks to test from the tip [default: 8]
       --use-reth                 Whether to query reth namespace
       --use-tracing              Whether to query tracing methods
       --use-all-txes             Whether to query every transacion from a block or just the first
       --skip-extended-eth        Skip extended eth methods not supported by all clients (e.g., `eth_getRawTransactionByBlockNumberAndIndex`)
       --timeout <TIMEOUT>        Maximum time to wait for syncing in seconds [default: 300]
       --rate-limit <RATE_LIMIT>  Maximum requests per second (rate limit)
-      --historical               Additionally test log-spaced historical blocks sampled backwards from the tip (head-128, head-1024, head-10000, head-100000, head-1000000)
-      --blocks <BLOCKS>          Additional pinned block numbers to test, comma separated
   -h, --help                     Print help
 ```
+
+In addition to the `[head - num_blocks + 1, head]` tip range, every run samples log-spaced
+historical blocks backwards from the tip (`head-128`, `head-1024`, `head-10000`, `head-100000`,
+`head-1000000`, capped at genesis). These exercise cold history such as static files and pruned
+tables that near-tip blocks do not.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,10 @@ Options:
       --use-reth                 Whether to query reth namespace
       --use-tracing              Whether to query tracing methods
       --use-all-txes             Whether to query every transacion from a block or just the first
-      --rate-limit <RATE_LIMIT>  Maximum requests per second (rate limit)
+      --skip-extended-eth        Skip extended eth methods not supported by all clients (e.g., `eth_getRawTransactionByBlockNumberAndIndex`)
       --timeout <TIMEOUT>        Maximum time to wait for syncing in seconds [default: 300]
+      --rate-limit <RATE_LIMIT>  Maximum requests per second (rate limit)
+      --historical               Additionally test log-spaced historical blocks sampled backwards from the tip (head-128, head-1024, head-10000, head-100000, head-1000000)
+      --blocks <BLOCKS>          Additional pinned block numbers to test, comma separated
   -h, --help                     Print help
 ```

--- a/crates/rpc-tester-cli/src/main.rs
+++ b/crates/rpc-tester-cli/src/main.rs
@@ -69,7 +69,9 @@ async fn main() -> eyre::Result<()> {
         .network::<AnyNetwork>()
         .on_http(args.rpc2);
 
-    let block_range = wait_for_readiness(&rpc1, &rpc2, args.num_blocks).await?;
+    let block_range =
+        wait_for_readiness(&rpc1, &rpc2, args.num_blocks, Duration::from_secs(args.timeout))
+            .await?;
 
     let tester = RpcTester::builder(rpc1, rpc2)
         .with_tracing(args.use_tracing)
@@ -99,18 +101,14 @@ pub async fn wait_for_readiness<P: Provider<AnyNetwork>>(
     rpc1: &P,
     rpc2: &P,
     block_size_range: u64,
+    timeout: Duration,
 ) -> eyre::Result<RangeInclusive<u64>> {
-    let args = CliArgs::parse();
     let start_time = Instant::now();
-    let timeout = Duration::from_secs(args.timeout);
 
     // Waits until it's done syncing
     while let SyncStatus::Info(sync_info) = rpc1.syncing().await? {
         if start_time.elapsed() > timeout {
-            return Err(eyre::eyre!(
-                "Timeout waiting for rpc1 to sync after {} seconds",
-                args.timeout
-            ));
+            return Err(eyre::eyre!("Timeout waiting for rpc1 to sync after {timeout:?}"));
         }
         info!(?sync_info, "rpc1 still syncing");
         tokio::time::sleep(Duration::from_secs(5)).await;
@@ -123,7 +121,8 @@ pub async fn wait_for_readiness<P: Provider<AnyNetwork>>(
 
         if tip1 >= tip2 || tip2 - tip1 <= 5 {
             let common = tip1.min(tip2);
-            let range = common - (block_size_range - 1)..=common;
+            // Saturate so young chains with fewer blocks than the requested range still work.
+            let range = common.saturating_sub(block_size_range.saturating_sub(1))..=common;
             info!(?range, "testing block range");
             return Ok(range);
         }

--- a/crates/rpc-tester-cli/src/main.rs
+++ b/crates/rpc-tester-cli/src/main.rs
@@ -3,7 +3,7 @@
 use alloy_provider::{network::AnyNetwork, Provider, ProviderBuilder};
 use alloy_rpc_types::SyncStatus;
 use clap::Parser;
-use rpc_tester::RpcTester;
+use rpc_tester::{historical_blocks, RpcTester};
 use std::{
     ops::RangeInclusive,
     time::{Duration, Instant},
@@ -52,6 +52,20 @@ pub struct CliArgs {
     /// If not provided, no rate limiting is applied.
     #[arg(long, value_name = "RATE_LIMIT")]
     pub rate_limit: Option<u32>,
+
+    /// Additionally test log-spaced historical blocks sampled backwards from the tip
+    /// (head-128, head-1024, head-10000, head-100000, head-1000000).
+    ///
+    /// This exercises cold history (static files, pruned tables) that near-tip blocks do not.
+    #[arg(long)]
+    pub historical: bool,
+
+    /// Additional pinned block numbers to test, comma separated.
+    ///
+    /// Useful for chain-specific edge cases such as fork transition blocks or blocks with rare
+    /// transaction types.
+    #[arg(long, value_name = "BLOCKS", value_delimiter = ',')]
+    pub blocks: Vec<u64>,
 }
 
 #[tokio::main]
@@ -71,15 +85,29 @@ async fn main() -> eyre::Result<()> {
 
     let block_range = wait_for_readiness(&rpc1, &rpc2, args.num_blocks).await?;
 
-    RpcTester::builder(rpc1, rpc2)
+    let tester = RpcTester::builder(rpc1, rpc2)
         .with_tracing(args.use_tracing)
         .with_reth(args.use_reth)
         .with_all_txes(args.use_all_txes)
         .skip_extended_eth(args.skip_extended_eth)
         .with_rate_limit(args.rate_limit)
-        .build()
-        .run(block_range)
-        .await
+        .build();
+
+    let mut extra_blocks = args.blocks;
+    if args.historical {
+        extra_blocks.extend(historical_blocks(*block_range.end()));
+    }
+    extra_blocks.sort_unstable();
+    extra_blocks.dedup();
+    extra_blocks.retain(|block| !block_range.contains(block));
+
+    // Run both suites to completion before failing so a diff in one does not hide the other.
+    let range_result = tester.run(block_range).await;
+    if !extra_blocks.is_empty() {
+        info!(blocks = ?extra_blocks, "testing historical blocks");
+        tester.run_blocks(extra_blocks).await?;
+    }
+    range_result
 }
 
 /// Waits until rpc1 is synced to the tip and returns a valid block range to test against rpc2.

--- a/crates/rpc-tester-cli/src/main.rs
+++ b/crates/rpc-tester-cli/src/main.rs
@@ -79,9 +79,10 @@ async fn main() -> eyre::Result<()> {
         .with_rate_limit(args.rate_limit)
         .build();
 
-    // Log-spaced historical samples reaching beyond the tip range. These exercise cold history
-    // (static files, pruned tables) that near-tip blocks do not.
-    let mut historical = historical_blocks(*block_range.end());
+    // Random historical samples reaching beyond the tip range: near-history picks crossing the
+    // persistence boundary of lazily persisting clients, plus one pick per deep-history stratum
+    // exercising cold storage. Randomness accumulates coverage across repeated runs.
+    let mut historical = historical_blocks(*block_range.end(), args.num_blocks as usize);
     historical.retain(|block| !block_range.contains(block));
 
     // Run both suites to completion before failing so a diff in one does not hide the other.

--- a/crates/rpc-tester-cli/src/main.rs
+++ b/crates/rpc-tester-cli/src/main.rs
@@ -24,7 +24,7 @@ pub struct CliArgs {
     pub rpc2: Url,
 
     /// Number of blocks to test from the tip.
-    #[arg(long, value_name = "NUM_BLOCKS", default_value = "32")]
+    #[arg(long, value_name = "NUM_BLOCKS", default_value = "8")]
     pub num_blocks: u64,
 
     /// Whether to query reth namespace
@@ -52,20 +52,6 @@ pub struct CliArgs {
     /// If not provided, no rate limiting is applied.
     #[arg(long, value_name = "RATE_LIMIT")]
     pub rate_limit: Option<u32>,
-
-    /// Additionally test log-spaced historical blocks sampled backwards from the tip
-    /// (head-128, head-1024, head-10000, head-100000, head-1000000).
-    ///
-    /// This exercises cold history (static files, pruned tables) that near-tip blocks do not.
-    #[arg(long)]
-    pub historical: bool,
-
-    /// Additional pinned block numbers to test, comma separated.
-    ///
-    /// Useful for chain-specific edge cases such as fork transition blocks or blocks with rare
-    /// transaction types.
-    #[arg(long, value_name = "BLOCKS", value_delimiter = ',')]
-    pub blocks: Vec<u64>,
 }
 
 #[tokio::main]
@@ -93,19 +79,16 @@ async fn main() -> eyre::Result<()> {
         .with_rate_limit(args.rate_limit)
         .build();
 
-    let mut extra_blocks = args.blocks;
-    if args.historical {
-        extra_blocks.extend(historical_blocks(*block_range.end()));
-    }
-    extra_blocks.sort_unstable();
-    extra_blocks.dedup();
-    extra_blocks.retain(|block| !block_range.contains(block));
+    // Log-spaced historical samples reaching beyond the tip range. These exercise cold history
+    // (static files, pruned tables) that near-tip blocks do not.
+    let mut historical = historical_blocks(*block_range.end());
+    historical.retain(|block| !block_range.contains(block));
 
     // Run both suites to completion before failing so a diff in one does not hide the other.
     let range_result = tester.run(block_range).await;
-    if !extra_blocks.is_empty() {
-        info!(blocks = ?extra_blocks, "testing historical blocks");
-        tester.run_blocks(extra_blocks).await?;
+    if !historical.is_empty() {
+        info!(blocks = ?historical, "testing historical blocks");
+        tester.run_blocks(historical).await?;
     }
     range_result
 }

--- a/crates/rpc-tester/Cargo.toml
+++ b/crates/rpc-tester/Cargo.toml
@@ -22,3 +22,7 @@ serde = { workspace = true, default-features = false }
 serde_json.workspace = true
 tokio = { workspace = true, default-features = false }
 tracing.workspace = true
+
+[dev-dependencies]
+alloy-node-bindings.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }

--- a/crates/rpc-tester/src/lib.rs
+++ b/crates/rpc-tester/src/lib.rs
@@ -7,7 +7,9 @@ mod tester;
 pub use tester::RpcTester;
 mod report;
 mod sampling;
-pub use sampling::{historical_blocks, HISTORICAL_OFFSETS};
+pub use sampling::{
+    historical_blocks, DEEP_STRATA, NEAR_WINDOW_MAX_OFFSET, NEAR_WINDOW_MIN_OFFSET,
+};
 
 /// Equality rpc test error
 enum TestError {

--- a/crates/rpc-tester/src/lib.rs
+++ b/crates/rpc-tester/src/lib.rs
@@ -6,6 +6,8 @@ pub mod get_logs;
 mod tester;
 pub use tester::RpcTester;
 mod report;
+mod sampling;
+pub use sampling::{historical_blocks, HISTORICAL_OFFSETS};
 
 /// Equality rpc test error
 enum TestError {

--- a/crates/rpc-tester/src/sampling.rs
+++ b/crates/rpc-tester/src/sampling.rs
@@ -1,0 +1,44 @@
+//! Helpers for sampling historical blocks.
+
+use alloy_primitives::BlockNumber;
+
+/// Log-spaced offsets from the chain head used by [`historical_blocks`].
+///
+/// Recent blocks are typically served from in-memory or hot storage, while deeper blocks exercise
+/// cold history such as static files or pruned tables. Log-spacing keeps the number of sampled
+/// blocks small while still crossing those boundaries.
+pub const HISTORICAL_OFFSETS: [u64; 5] = [128, 1_024, 10_000, 100_000, 1_000_000];
+
+/// Returns log-spaced historical block numbers sampled backwards from `head`.
+///
+/// Applies every offset in [`HISTORICAL_OFFSETS`], skipping offsets that would reach past genesis.
+/// The result is sorted ascending and deduplicated.
+pub fn historical_blocks(head: BlockNumber) -> Vec<BlockNumber> {
+    let mut blocks: Vec<BlockNumber> =
+        HISTORICAL_OFFSETS.iter().filter_map(|offset| head.checked_sub(*offset)).collect();
+    blocks.sort_unstable();
+    blocks.dedup();
+    blocks
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn samples_all_offsets_on_deep_chain() {
+        let head = 10_000_000;
+        assert_eq!(
+            historical_blocks(head),
+            vec![9_000_000, 9_900_000, 9_990_000, 9_998_976, 9_999_872]
+        );
+    }
+
+    #[test]
+    fn skips_offsets_past_genesis() {
+        assert_eq!(historical_blocks(10_000), vec![0, 8_976, 9_872]);
+        assert_eq!(historical_blocks(128), vec![0]);
+        assert_eq!(historical_blocks(127), Vec::<BlockNumber>::new());
+        assert_eq!(historical_blocks(0), Vec::<BlockNumber>::new());
+    }
+}

--- a/crates/rpc-tester/src/sampling.rs
+++ b/crates/rpc-tester/src/sampling.rs
@@ -1,24 +1,86 @@
 //! Helpers for sampling historical blocks.
 
 use alloy_primitives::BlockNumber;
+use std::time::{SystemTime, UNIX_EPOCH};
 
-/// Log-spaced offsets from the chain head used by [`historical_blocks`].
-///
-/// Recent blocks are typically served from in-memory or hot storage, while deeper blocks exercise
-/// cold history such as static files or pruned tables. Log-spacing keeps the number of sampled
-/// blocks small while still crossing those boundaries.
-pub const HISTORICAL_OFFSETS: [u64; 5] = [128, 1_024, 10_000, 100_000, 1_000_000];
+/// Shallowest offset of the near-history window, exclusive of the tip range.
+pub const NEAR_WINDOW_MIN_OFFSET: u64 = 8;
 
-/// Returns log-spaced historical block numbers sampled backwards from `head`.
+/// Deepest offset of the near-history window.
 ///
-/// Applies every offset in [`HISTORICAL_OFFSETS`], skipping offsets that would reach past genesis.
-/// The result is sorted ascending and deduplicated.
-pub fn historical_blocks(head: BlockNumber) -> Vec<BlockNumber> {
-    let mut blocks: Vec<BlockNumber> =
-        HISTORICAL_OFFSETS.iter().filter_map(|offset| head.checked_sub(*offset)).collect();
+/// Blocks in `[head - NEAR_WINDOW_MAX_OFFSET, head - NEAR_WINDOW_MIN_OFFSET]` span the region
+/// where clients with lazy persistence cross from in-memory state to persisted storage, so
+/// random samples from this window exercise both sides of that boundary.
+pub const NEAR_WINDOW_MAX_OFFSET: u64 = 128;
+
+/// Deep-history offset strata. One block is sampled uniformly from each `(start, end]` offset
+/// range, keeping depth coverage log-spread without fixed blind spots between samples.
+pub const DEEP_STRATA: [(u64, u64); 4] =
+    [(128, 1_024), (1_024, 10_000), (10_000, 100_000), (100_000, 1_000_000)];
+
+/// Returns randomly sampled historical block numbers below `head`.
+///
+/// Samples `near_samples` blocks uniformly from the near-history window (see
+/// [`NEAR_WINDOW_MAX_OFFSET`]) plus one block per [`DEEP_STRATA`] stratum, skipping any range
+/// that reaches past genesis. The result is sorted ascending and deduplicated, so it may contain
+/// fewer entries than requested. Randomness means repeated runs accumulate coverage instead of
+/// re-testing the same blocks; the caller should log the sampled set.
+pub fn historical_blocks(head: BlockNumber, near_samples: usize) -> Vec<BlockNumber> {
+    sample_blocks(head, near_samples, &mut Rng::from_entropy())
+}
+
+/// Deterministic core of [`historical_blocks`].
+fn sample_blocks(head: BlockNumber, near_samples: usize, rng: &mut Rng) -> Vec<BlockNumber> {
+    let mut blocks = Vec::new();
+
+    if head > NEAR_WINDOW_MIN_OFFSET {
+        let max_offset = NEAR_WINDOW_MAX_OFFSET.min(head);
+        for _ in 0..near_samples {
+            blocks.push(head - rng.sample_range(NEAR_WINDOW_MIN_OFFSET, max_offset));
+        }
+    }
+
+    for (start, end) in DEEP_STRATA {
+        if head <= start {
+            break;
+        }
+        let end = end.min(head);
+        blocks.push(head - rng.sample_range(start + 1, end));
+    }
+
     blocks.sort_unstable();
     blocks.dedup();
     blocks
+}
+
+/// Minimal xorshift64* generator.
+///
+/// The sampling here has no quality or security requirements, so this avoids pulling in a rng
+/// crate.
+struct Rng(u64);
+
+impl Rng {
+    /// Seeds the generator from the system clock.
+    fn from_entropy() -> Self {
+        let nanos = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().subsec_nanos();
+        let secs = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_secs();
+        // Never zero, which would make xorshift degenerate.
+        Self((u64::from(nanos) << 32 | secs & 0xffff_ffff) | 1)
+    }
+
+    fn next(&mut self) -> u64 {
+        let mut x = self.0;
+        x ^= x << 13;
+        x ^= x >> 7;
+        x ^= x << 17;
+        self.0 = x;
+        x.wrapping_mul(0x2545_F491_4F6C_DD1D)
+    }
+
+    /// Returns a value in `[min, max]`. The modulo bias is irrelevant at these range sizes.
+    fn sample_range(&mut self, min: u64, max: u64) -> u64 {
+        min + self.next() % (max - min + 1)
+    }
 }
 
 #[cfg(test)]
@@ -26,19 +88,53 @@ mod tests {
     use super::*;
 
     #[test]
-    fn samples_all_offsets_on_deep_chain() {
+    fn samples_stay_in_their_ranges() {
         let head = 10_000_000;
+        let blocks = sample_blocks(head, 8, &mut Rng(42));
+
+        let near: Vec<_> = blocks
+            .iter()
+            .filter(|b| {
+                **b >= head - NEAR_WINDOW_MAX_OFFSET && **b <= head - NEAR_WINDOW_MIN_OFFSET
+            })
+            .collect();
+        assert!(!near.is_empty() && near.len() <= 8);
+
+        for (start, end) in DEEP_STRATA {
+            let in_stratum =
+                blocks.iter().filter(|b| **b >= head - end && **b < head - start).count();
+            assert_eq!(in_stratum, 1, "expected exactly one sample in stratum ({start}, {end}]");
+        }
+
+        assert!(blocks.windows(2).all(|w| w[0] < w[1]), "sorted and deduplicated");
+    }
+
+    #[test]
+    fn deterministic_for_same_seed() {
         assert_eq!(
-            historical_blocks(head),
-            vec![9_000_000, 9_900_000, 9_990_000, 9_998_976, 9_999_872]
+            sample_blocks(10_000_000, 8, &mut Rng(7)),
+            sample_blocks(10_000_000, 8, &mut Rng(7))
+        );
+        assert_ne!(
+            sample_blocks(10_000_000, 8, &mut Rng(7)),
+            sample_blocks(10_000_000, 8, &mut Rng(8))
         );
     }
 
     #[test]
-    fn skips_offsets_past_genesis() {
-        assert_eq!(historical_blocks(10_000), vec![0, 8_976, 9_872]);
-        assert_eq!(historical_blocks(128), vec![0]);
-        assert_eq!(historical_blocks(127), Vec::<BlockNumber>::new());
-        assert_eq!(historical_blocks(0), Vec::<BlockNumber>::new());
+    fn young_chains_clamp_to_genesis() {
+        // Head below the near window: nothing to sample.
+        assert!(sample_blocks(8, 8, &mut Rng(1)).is_empty());
+        assert!(sample_blocks(0, 8, &mut Rng(1)).is_empty());
+
+        // Head inside the near window: samples stay within [0, head - min offset].
+        let blocks = sample_blocks(100, 8, &mut Rng(1));
+        assert!(!blocks.is_empty());
+        assert!(blocks.iter().all(|b| *b <= 100 - NEAR_WINDOW_MIN_OFFSET));
+
+        // Head inside a deep stratum: the partial stratum is still sampled, deeper ones skipped.
+        let blocks = sample_blocks(2_000, 0, &mut Rng(1));
+        assert_eq!(blocks.len(), 2);
+        assert!(blocks.iter().all(|b| *b < 2_000 - 128));
     }
 }

--- a/crates/rpc-tester/src/tester.rs
+++ b/crates/rpc-tester/src/tester.rs
@@ -136,6 +136,15 @@ where
                     if let Some(log) = receipt.inner.inner.logs().first().map(|l| l.address()) {
                         #[rustfmt::skip]
                         tests.push(get_logs!(self, Filter::new().select(block_number).address(log)));
+
+                        // State of the contract that emitted the log at this block. These hit the
+                        // bytecode and (historical) storage paths, which no other call exercises.
+                        #[rustfmt::skip]
+                        let state_calls = vec![
+                            rpc_with_block!(self, get_code_at, log; block_id),
+                            rpc_with_block!(self, get_storage_at, log, U256::ZERO; block_id),
+                        ];
+                        tests.extend(state_calls);
                     }
 
                     if let Some(topic) = receipt
@@ -162,6 +171,9 @@ where
                     rpc!(self, get_transaction_receipt, tx_hash),
                     rpc_with_block!(self, get_transaction_count, tx_from; block_id),
                     rpc_with_block!(self, get_balance, tx_from; block_id),
+                    // Senders are usually EOAs, but EIP-7702 delegations make sender code
+                    // observable.
+                    rpc_with_block!(self, get_code_at, tx_from; block_id),
                     rpc!(self, debug_trace_transaction, tx_hash, tracer_opts),
                 ];
                 tests.extend(tx_calls);

--- a/crates/rpc-tester/src/tester.rs
+++ b/crates/rpc-tester/src/tester.rs
@@ -71,11 +71,23 @@ where
         Ok(())
     }
 
+    /// Verifies RPC calls applicable to single blocks for each of the given blocks.
+    ///
+    /// Unlike [`Self::run`], this does not run block range tests, so the blocks do not need to be
+    /// contiguous. This is intended for sampled historical blocks, see
+    /// [`historical_blocks`](crate::historical_blocks).
+    pub async fn run_blocks(&self, blocks: impl IntoIterator<Item = BlockNumber>) -> Result<()> {
+        self.test_per_block(blocks).await
+    }
+
     /// Verifies RPC calls applicable to single blocks.
-    async fn test_per_block(&self, block_range: RangeInclusive<u64>) -> Result<(), eyre::Error> {
+    async fn test_per_block(
+        &self,
+        blocks: impl IntoIterator<Item = BlockNumber>,
+    ) -> Result<(), eyre::Error> {
         let mut results = BlockTestResults::new();
 
-        for block_number in block_range {
+        for block_number in blocks {
             info!(block_number, "testing rpc");
 
             let mut tests = vec![];
@@ -210,8 +222,12 @@ where
             .rpc2
             .get_block_by_number(block_number.into(), true.into())
             .await?
-            .expect("should have block from range");
-        assert_eq!(block.header.number, block_number);
+            .ok_or_else(|| eyre::eyre!("block {block_number} not found on rpc2"))?;
+        eyre::ensure!(
+            block.header.number == block_number,
+            "rpc2 returned block {} for requested block {block_number}",
+            block.header.number
+        );
         let block_hash = block.header.hash;
         let block_tag = BlockNumberOrTag::Number(block_number);
         let block_id = BlockId::Number(block_tag);

--- a/crates/rpc-tester/tests/same_node.rs
+++ b/crates/rpc-tester/tests/same_node.rs
@@ -15,12 +15,13 @@ use std::time::Duration;
 const ALICE: &str = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
 const BOB: &str = "0x70997970C51812dc3A010C7d01b50e0d17dc79C8";
 
-/// Init code that emits a `LOG1` with a fixed topic and deploys an empty contract:
-/// `PUSH32 topic PUSH1 0 PUSH1 0 LOG1 STOP`.
+/// Init code that stores `1` at slot 0, emits a `LOG1` with a fixed topic, and deploys an empty
+/// contract: `PUSH1 1 PUSH1 0 SSTORE PUSH32 topic PUSH1 0 PUSH1 0 LOG1 STOP`.
 ///
-/// This gives us a receipt with a log so the receipt-derived `eth_getLogs` filters are exercised.
+/// This gives us a receipt with a log so the receipt-derived `eth_getLogs` filters are exercised,
+/// and non-empty contract storage for the state calls.
 const LOG_EMITTER_INIT_CODE: &str =
-    "0x7faaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa60006000a100";
+    "0x60016000557faaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa60006000a100";
 
 fn provider(anvil: &AnvilInstance) -> impl Provider<AnyNetwork> + Clone {
     ProviderBuilder::new()

--- a/crates/rpc-tester/tests/same_node.rs
+++ b/crates/rpc-tester/tests/same_node.rs
@@ -1,0 +1,82 @@
+//! Self-test running the tester against a single anvil node.
+//!
+//! Pointing `rpc1` and `rpc2` at the same node must always succeed, so this catches bugs in the
+//! tester itself (request construction, comparison, pagination, reporting) without needing two
+//! live nodes. Requires `anvil` to be installed.
+
+use alloy_node_bindings::{Anvil, AnvilInstance};
+use alloy_primitives::B256;
+use alloy_provider::{network::AnyNetwork, Provider, ProviderBuilder};
+use rpc_tester::RpcTester;
+use serde_json::json;
+use std::time::Duration;
+
+/// First two anvil dev accounts.
+const ALICE: &str = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
+const BOB: &str = "0x70997970C51812dc3A010C7d01b50e0d17dc79C8";
+
+/// Init code that emits a `LOG1` with a fixed topic and deploys an empty contract:
+/// `PUSH32 topic PUSH1 0 PUSH1 0 LOG1 STOP`.
+///
+/// This gives us a receipt with a log so the receipt-derived `eth_getLogs` filters are exercised.
+const LOG_EMITTER_INIT_CODE: &str =
+    "0x7faaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa60006000a100";
+
+fn provider(anvil: &AnvilInstance) -> impl Provider<AnyNetwork> + Clone {
+    ProviderBuilder::new()
+        .disable_recommended_fillers()
+        .network::<AnyNetwork>()
+        .on_http(anvil.endpoint_url())
+}
+
+/// Sends a transaction from an unlocked dev account and waits until it is mined.
+async fn send_and_mine<P: Provider<AnyNetwork>>(provider: &P, tx: serde_json::Value) {
+    let hash: B256 =
+        provider.raw_request("eth_sendTransaction".into(), [tx]).await.expect("send tx");
+    for _ in 0..50 {
+        if provider.get_transaction_receipt(hash).await.expect("get receipt").is_some() {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    panic!("transaction {hash} was not mined");
+}
+
+/// Populates the chain with a value transfer, a log-emitting contract deployment, and an empty
+/// block, and returns the chain head.
+async fn populate_chain<P: Provider<AnyNetwork>>(provider: &P) -> u64 {
+    send_and_mine(provider, json!({ "from": ALICE, "to": BOB, "value": "0x2540be400" })).await;
+    send_and_mine(provider, json!({ "from": ALICE, "data": LOG_EMITTER_INIT_CODE })).await;
+    let _: serde_json::Value = provider.raw_request("evm_mine".into(), ()).await.expect("evm_mine");
+
+    let head = provider.get_block_number().await.expect("get head");
+    assert!(head >= 3, "expected at least 3 blocks, got {head}");
+    head
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn same_node_passes() {
+    let anvil = Anvil::new().try_spawn().expect("anvil must be installed");
+    let head = populate_chain(&provider(&anvil)).await;
+
+    let tester = RpcTester::builder(provider(&anvil), provider(&anvil))
+        .with_tracing(true)
+        .with_all_txes(true)
+        .build();
+
+    // Full suite over the whole chain, including the empty genesis block.
+    tester.run(0..=head).await.expect("same node must be a superset of itself");
+
+    // Sampled non-contiguous blocks, as used by historical mode.
+    tester.run_blocks([0, head]).await.expect("same node must be a superset of itself");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn missing_block_errors() {
+    let anvil = Anvil::new().try_spawn().expect("anvil must be installed");
+    let head = populate_chain(&provider(&anvil)).await;
+
+    let tester = RpcTester::builder(provider(&anvil), provider(&anvil)).build();
+    let result = tester.run_blocks([head + 1000]).await;
+    assert!(result.is_err(), "requesting a block beyond the tip must error, not panic");
+}


### PR DESCRIPTION
The only state the tester touched was sender balance and nonce, so the bytecode and storage retrieval paths went completely untested. For the contract that emitted each inspected receipt's first log, we now compare `eth_getCode` and `eth_getStorageAt` (slot 0) at the tested block; for transaction senders we compare `eth_getCode`, which is observable under EIP-7702 delegations. Combined with the default historical sampling this exercises bytecode and storage reads against cold history.

The anvil self-test contract now also writes storage slot 0 so the storage calls compare non-empty state.

Stacked on #31. Part of #29