### PR TITLE
feat: add error parity and miss-path probes

### DIFF
--- a/crates/rpc-tester/src/lib.rs
+++ b/crates/rpc-tester/src/lib.rs
@@ -14,6 +14,7 @@ pub use sampling::{
 /// Equality rpc test error
 enum TestError {
     Diff { rpc1: serde_json::Value, rpc2: serde_json::Value, args: Option<String> },
+    ErrDiff { rpc1: String, rpc2: String, args: Option<String> },
     Rpc1Err(String),
     Rpc2Err(String),
 }

--- a/crates/rpc-tester/src/report.rs
+++ b/crates/rpc-tester/src/report.rs
@@ -42,6 +42,16 @@ pub(crate) fn report(results_by_block: ReportResults) -> eyre::Result<()> {
                         println!("{diffs}");
                     }
                 }
+                Err(TestError::ErrDiff { rpc1, rpc2, args }) => {
+                    passed_title = false;
+                    println!("\n{title} ❌");
+                    println!("    {name}: ❌ Error mismatch");
+                    if let Some(args) = args {
+                        println!("      args: {args}");
+                    }
+                    println!("      rpc1: {rpc1}");
+                    println!("      rpc2: {rpc2}");
+                }
                 Err(TestError::Rpc1Err(err) | TestError::Rpc2Err(err)) => {
                     passed_title = false;
                     println!("\n{title} ❌");

--- a/crates/rpc-tester/src/tester.rs
+++ b/crates/rpc-tester/src/tester.rs
@@ -14,6 +14,7 @@ use alloy_rpc_types_trace::{
     geth::{GethDebugBuiltInTracerType, GethDebugTracerType, GethDebugTracingOptions},
     parity::TraceType,
 };
+use alloy_transport::TransportError;
 use eyre::Result;
 use futures::Future;
 use serde::Serialize;
@@ -69,7 +70,8 @@ where
     /// Verifies that results from `rpc1` are at least a superset of `rpc2`.
     pub async fn run(&self, block_range: RangeInclusive<BlockNumber>) -> Result<()> {
         self.test_per_block(block_range.clone()).await?;
-        self.test_block_range(block_range).await?;
+        self.test_block_range(block_range.clone()).await?;
+        self.test_negative(*block_range.end()).await?;
         Ok(())
     }
 
@@ -248,6 +250,33 @@ where
         Ok(())
     }
 
+    /// Verifies that both nodes agree on requests for data that does not exist.
+    ///
+    /// Clients diverge a lot on the miss path: null vs error responses, and error codes for
+    /// invalid requests. All probes use inputs that cannot exist, so both nodes must return the
+    /// same null response or the same error.
+    async fn test_negative(&self, head: BlockNumber) -> Result<(), eyre::Error> {
+        let missing_hash = B256::repeat_byte(0xff);
+        let future_tag = BlockNumberOrTag::Number(head.saturating_add(1_000_000));
+        let head_tag = BlockNumberOrTag::Number(head);
+
+        #[rustfmt::skip]
+        let tests = vec![
+            rpc!(self, get_block_by_hash, missing_hash, alloy_rpc_types::BlockTransactionsKind::Full),
+            rpc!(self, get_block_by_number, future_tag, alloy_rpc_types::BlockTransactionsKind::Full),
+            rpc!(self, get_block_transaction_count_by_number, future_tag),
+            rpc!(self, get_block_receipts, BlockId::Number(future_tag)),
+            rpc!(self, get_transaction_by_hash, missing_hash),
+            rpc!(self, get_raw_transaction_by_hash, missing_hash),
+            rpc!(self, get_transaction_receipt, missing_hash),
+            rpc!(self, get_transaction_by_block_number_and_index, head_tag, 100_000usize),
+            rpc!(self, trace_transaction, missing_hash),
+            rpc!(self, debug_trace_transaction, missing_hash, call_tracer_opts()),
+        ];
+
+        report(vec![("Negative probes".to_string(), futures::future::join_all(tests).await)])
+    }
+
     /// Fetches block and block identifiers from `self.truth`.
     async fn fetch_block(
         &self,
@@ -289,7 +318,7 @@ where
     /// Compares the response to a specific method between both rpcs. Only collects differences.
     ///
     /// If any namespace is disabled skip it.
-    async fn test_rpc_call<'a, F, Fut, T, E>(
+    async fn test_rpc_call<'a, F, Fut, T>(
         &'a self,
         name: &str,
         args: Option<String>,
@@ -297,9 +326,8 @@ where
     ) -> (MethodName, Result<(), TestError>)
     where
         F: Fn(&'a P) -> Fut + 'a,
-        Fut: std::future::Future<Output = Result<T, E>> + 'a + Send,
+        Fut: std::future::Future<Output = Result<T, TransportError>> + 'a + Send,
         T: PartialEq + Debug + Serialize,
-        E: Debug,
     {
         if name.starts_with("reth") && !self.use_reth || name.contains("trace") && !self.use_tracing
         {
@@ -327,11 +355,35 @@ where
                     })
                 }
             }
+            // Both nodes rejecting the call with the same error response is agreement, e.g. a
+            // deliberate miss-path probe or a namespace disabled on both nodes.
+            (Err(e1), Err(e2)) => {
+                if errors_match(&e1, &e2) {
+                    Ok(())
+                } else {
+                    Err(TestError::ErrDiff {
+                        rpc1: format!("{e1:?}"),
+                        rpc2: format!("{e2:?}"),
+                        args,
+                    })
+                }
+            }
             (Err(e), _) => Err(TestError::Rpc1Err(format!("rpc1: {e:?}"))),
             (Ok(_), Err(e)) => Err(TestError::Rpc2Err(format!("rpc2: {e:?}"))),
         };
 
         (name.to_string(), result)
+    }
+}
+
+/// Returns whether two RPC errors are the same error response.
+///
+/// Only JSON-RPC error responses are compared (by code and message); transport-level failures
+/// such as timeouts are never treated as agreement.
+fn errors_match(e1: &TransportError, e2: &TransportError) -> bool {
+    match (e1.as_error_resp(), e2.as_error_resp()) {
+        (Some(r1), Some(r2)) => r1.code == r2.code && r1.message == r2.message,
+        _ => false,
     }
 }
 
@@ -428,5 +480,46 @@ impl<P: Provider<AnyNetwork>> RpcTesterBuilder<P> {
             rate_limit_rps: self.rate_limit_rps,
             last_request_time: tokio::sync::Mutex::new(std::time::Instant::now()),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_json_rpc::ErrorPayload;
+    use alloy_transport::TransportErrorKind;
+
+    fn error_resp(code: i64, message: &str) -> TransportError {
+        TransportError::ErrorResp(ErrorPayload {
+            code,
+            message: message.to_string().into(),
+            data: None,
+        })
+    }
+
+    #[test]
+    fn matching_error_responses_agree() {
+        assert!(errors_match(
+            &error_resp(-32000, "transaction not found"),
+            &error_resp(-32000, "transaction not found")
+        ));
+    }
+
+    #[test]
+    fn different_error_responses_diverge() {
+        assert!(!errors_match(
+            &error_resp(-32000, "transaction not found"),
+            &error_resp(-32601, "transaction not found")
+        ));
+        assert!(!errors_match(&error_resp(-32000, "a"), &error_resp(-32000, "b")));
+    }
+
+    #[test]
+    fn transport_errors_never_agree() {
+        assert!(!errors_match(
+            &TransportErrorKind::backend_gone(),
+            &TransportErrorKind::backend_gone()
+        ));
+        assert!(!errors_match(&TransportErrorKind::backend_gone(), &error_resp(-32000, "a")));
     }
 }


### PR DESCRIPTION
Every query so far used data known to exist, and any RPC error failed the run outright. That has two problems: legitimate agreement on errors (both nodes rejecting a historical `eth_getProof`, or a namespace disabled on both) failed the run, and the miss path — where clients diverge the most, null vs error and differing error codes per EIP-1474 — was never tested at all.

`test_rpc_call` now treats both nodes returning the same JSON-RPC error response (same code and message) as agreement, and reports mismatched errors as a dedicated error-mismatch failure showing both sides. Transport-level failures such as timeouts are never treated as agreement, so a dead node cannot masquerade as a passing run. On top of that, `run` now ends with a set of negative probes requesting data that cannot exist: a missing tx hash across the tx/receipt/raw/trace methods, a far-future block for block queries, and an out-of-range transaction index.

Stacked on #33. Part of #29