### PR TITLE
feat: extend eth_getLogs filter coverage

### DIFF
--- a/crates/rpc-tester/src/get_logs.rs
+++ b/crates/rpc-tester/src/get_logs.rs
@@ -4,6 +4,7 @@ use alloy_primitives::BlockNumber;
 use alloy_provider::{network::AnyNetwork, Provider};
 use alloy_rpc_types::{BlockNumberOrTag, Filter, Log};
 use futures::FutureExt;
+use tracing::warn;
 
 /// The result type returned by `get_logs`.
 pub type GetLogsResult<T> =
@@ -47,6 +48,14 @@ fn get_logs_paginated<'a, P: Provider<AnyNetwork>>(
                 let Some((suggested_from, suggested_to)) = parse_max_results_error(&e) else {
                     return Err(e);
                 };
+
+                // Surface pagination: if only one node paginates, the compared results are
+                // client-side concatenations rather than single server responses, which can mask
+                // server-side ordering or limit bugs.
+                warn!(
+                    ?filter,
+                    suggested_from, suggested_to, "eth_getLogs exceeded max results, paginating"
+                );
 
                 let Some(suggested_chunk) =
                     suggested_to.checked_sub(suggested_from).and_then(|d| d.checked_add(1))

--- a/crates/rpc-tester/src/tester.rs
+++ b/crates/rpc-tester/src/tester.rs
@@ -130,6 +130,7 @@ where
                 rpc!(self, debug_trace_block_by_number, block_tag, call_tracer_opts()),
                 rpc!(self, debug_trace_block_by_number, block_tag, prestate_tracer_opts()),
                 get_logs!(self, &Filter::new().select(block_number)),
+                get_logs!(self, &Filter::new().at_block_hash(block_hash)),
                 get_logs!(self, &Filter::new().select(block_number).address(vec![
                     "0x6b175474e89094c44da98b954eedeac495271d0f".parse::<Address>().unwrap(), // dai
                     "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48".parse::<Address>().unwrap(), // usdc
@@ -184,6 +185,36 @@ where
                         tests.push(
                             get_logs!(self, Filter::new().select(block_number).event_signature(topic))
                         );
+                    }
+
+                    // Multi-topic filter combining topic0 and topic1 of the same log, which
+                    // exercises positional topic matching instead of just the signature index.
+                    if let Some(log) =
+                        receipt.inner.inner.logs().iter().find(|log| log.topics().len() >= 2)
+                    {
+                        let (topic0, topic1) = (log.topics()[0], log.topics()[1]);
+                        #[rustfmt::skip]
+                        tests.push(get_logs!(
+                            self,
+                            Filter::new().select(block_number).event_signature(topic0).topic1(topic1)
+                        ));
+                    }
+
+                    // OR-list filter over multiple event signatures.
+                    let mut signatures: Vec<B256> = receipt
+                        .inner
+                        .inner
+                        .logs()
+                        .iter()
+                        .filter_map(|log| log.topics().first().copied())
+                        .collect();
+                    signatures.sort_unstable();
+                    signatures.dedup();
+                    signatures.truncate(4);
+                    if signatures.len() >= 2 {
+                        let or_filter =
+                            Filter::new().select(block_number).event_signature(signatures);
+                        tests.push(get_logs!(self, or_filter));
                     }
                 }
 

--- a/crates/rpc-tester/tests/same_node.rs
+++ b/crates/rpc-tester/tests/same_node.rs
@@ -15,13 +15,15 @@ use std::time::Duration;
 const ALICE: &str = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
 const BOB: &str = "0x70997970C51812dc3A010C7d01b50e0d17dc79C8";
 
-/// Init code that stores `1` at slot 0, emits a `LOG1` with a fixed topic, and deploys an empty
-/// contract: `PUSH1 1 PUSH1 0 SSTORE PUSH32 topic PUSH1 0 PUSH1 0 LOG1 STOP`.
+/// Init code that stores `1` at slot 0, emits a `LOG2` with two fixed topics, and deploys an
+/// empty contract:
+/// `PUSH1 1 PUSH1 0 SSTORE PUSH32 topic2 PUSH32 topic1 PUSH1 0 PUSH1 0 LOG2 STOP`.
 ///
-/// This gives us a receipt with a log so the receipt-derived `eth_getLogs` filters are exercised,
-/// and non-empty contract storage for the state calls.
+/// This gives us a receipt with a two-topic log so the receipt-derived `eth_getLogs` filters
+/// (signature, positional topic, and multi-topic) are exercised, and non-empty contract storage
+/// for the state calls.
 const LOG_EMITTER_INIT_CODE: &str =
-    "0x60016000557faaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa60006000a100";
+    "0x60016000557fbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb7faaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa60006000a200";
 
 fn provider(anvil: &AnvilInstance) -> impl Provider<AnyNetwork> + Clone {
     ProviderBuilder::new()


### PR DESCRIPTION
`eth_getLogs` was only tested with number-range block selection, a single address list, and a single topic0. This adds the remaining filter shapes, all derived from receipt logs so they are guaranteed to match something: a `blockHash`-based filter (a separate resolution path from number ranges), a positional filter combining topic0 and topic1 of the same log, and an OR-list over multiple event signatures.

The max-results pagination helper now emits a warning when it kicks in. Pagination is applied per node, so when only one side paginates the comparison is between a client-side concatenation and a single server response — that can mask server-side ordering or limit bugs, and the warning makes it visible in the run output.

The anvil self-test contract now emits a two-topic log so the positional filter path is exercised in CI.

Stacked on #36. Part of #29