### PR TITLE
fix: address adversarial review findings

### DIFF
--- a/.github/workflows/live-smoke.yml
+++ b/.github/workflows/live-smoke.yml
@@ -1,7 +1,9 @@
 name: live-smoke
 
 # Smoke test against a live endpoint used as both rpc1 and rpc2: comparing a node against itself
-# must always succeed, so a failure indicates a bug in the tester (or an endpoint outage).
+# should succeed, so a failure usually indicates a bug in the tester or an endpoint outage. Note
+# that a load-balanced endpoint can route the two clients to backends at slightly different
+# heights, so near-tip flakes are possible; persistent failures are the signal.
 
 on:
   workflow_dispatch:
@@ -36,4 +38,4 @@ jobs:
           --rpc1 "$RPC"
           --rpc2 "$RPC"
           --num-blocks 3
-          --rate-limit 20
+          --rate-limit 10

--- a/README.md
+++ b/README.md
@@ -26,3 +26,7 @@ pick per log-spaced deep-history stratum (offsets up to 1024, 10000, 100000 and 
 at genesis). Deep samples exercise cold history such as static files and pruned tables that
 near-tip blocks do not, and randomness means repeated runs accumulate coverage instead of
 re-testing the same blocks. The sampled set is logged at startup.
+
+Note that the deep samples query state and replay transactions at historical blocks, which
+assumes both nodes serve full historical state (archive). Also, `--num-blocks` values of 128 or
+more make the tip range swallow the near-history window, dropping those samples.

--- a/crates/rpc-tester-cli/src/main.rs
+++ b/crates/rpc-tester-cli/src/main.rs
@@ -45,6 +45,12 @@ pub struct CliArgs {
     #[arg(long)]
     pub skip_extended_eth: bool,
 
+    /// Whether to compare the moving `safe` and `finalized` tags.
+    ///
+    /// Requires both nodes to share a consensus view, otherwise the tags can legitimately differ.
+    #[arg(long)]
+    pub use_finality_tags: bool,
+
     /// Maximum time to wait for syncing in seconds
     #[arg(long, value_name = "TIMEOUT", default_value = "300")]
     pub timeout: u64,
@@ -53,12 +59,6 @@ pub struct CliArgs {
     /// If not provided, no rate limiting is applied.
     #[arg(long, value_name = "RATE_LIMIT")]
     pub rate_limit: Option<u32>,
-
-    /// Whether to compare the moving `safe` and `finalized` tags.
-    ///
-    /// Requires both nodes to share a consensus view, otherwise the tags can legitimately differ.
-    #[arg(long)]
-    pub use_finality_tags: bool,
 }
 
 #[tokio::main]
@@ -89,16 +89,14 @@ async fn main() -> eyre::Result<()> {
         .with_rate_limit(args.rate_limit)
         .build();
 
-    // Random historical samples reaching beyond the tip range: near-history picks crossing the
-    // persistence boundary of lazily persisting clients, plus one pick per deep-history stratum
-    // exercising cold storage. Randomness accumulates coverage across repeated runs.
+    // Random historical samples beyond the tip range; see `historical_blocks` for the scheme.
     let mut historical = historical_blocks(*block_range.end(), args.num_blocks as usize);
     historical.retain(|block| !block_range.contains(block));
+    info!(blocks = ?historical, "sampled historical blocks");
 
     // Run both suites to completion before failing so a diff in one does not hide the other.
     let range_result = tester.run(block_range).await;
     if !historical.is_empty() {
-        info!(blocks = ?historical, "testing historical blocks");
         tester.run_blocks(historical).await?;
     }
     range_result

--- a/crates/rpc-tester/src/report.rs
+++ b/crates/rpc-tester/src/report.rs
@@ -43,8 +43,10 @@ pub(crate) fn report(results_by_block: ReportResults) -> eyre::Result<()> {
                     }
                 }
                 Err(TestError::ErrDiff { rpc1, rpc2, args }) => {
-                    passed_title = false;
-                    println!("\n{title} ❌");
+                    if passed_title {
+                        passed_title = false;
+                        println!("\n{title} ❌");
+                    }
                     println!("    {name}: ❌ Error mismatch");
                     if let Some(args) = args {
                         println!("      args: {args}");
@@ -53,8 +55,10 @@ pub(crate) fn report(results_by_block: ReportResults) -> eyre::Result<()> {
                     println!("      rpc2: {rpc2}");
                 }
                 Err(TestError::Rpc1Err(err) | TestError::Rpc2Err(err)) => {
-                    passed_title = false;
-                    println!("\n{title} ❌");
+                    if passed_title {
+                        passed_title = false;
+                        println!("\n{title} ❌");
+                    }
                     println!("    {name}: ❌ {err}");
                 }
             }
@@ -90,6 +94,10 @@ fn filter_ignored_fields(value: Value) -> Value {
 }
 
 /// Verifies if there is any missing field/element from rpc1 comparing it to rpc2.
+///
+/// Note that the superset semantics of `assert_json_include` only apply to object keys. Arrays
+/// are compared positionally: extra trailing elements in rpc1 are tolerated, but an extra element
+/// anywhere else shifts subsequent indices and fails.
 fn verify_missing_or_mismatch(rpc1: Value, rpc2: Value) -> Option<String> {
     let default_panic_hook = std::panic::take_hook();
 
@@ -113,4 +121,54 @@ fn verify_missing_or_mismatch(rpc1: Value, rpc2: Value) -> Option<String> {
         return Some(err_msg);
     }
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    // A single test so the panic-hook manipulation in `verify_missing_or_mismatch` is never
+    // raced by a parallel test.
+    #[test]
+    fn report_detects_diffs() {
+        // rpc1 being a strict superset of rpc2 passes.
+        let superset = TestError::Diff {
+            rpc1: json!({ "a": 1, "extra": 2 }),
+            rpc2: json!({ "a": 1 }),
+            args: None,
+        };
+        assert!(report(vec![("t".to_string(), vec![("m".to_string(), Err(superset))])]).is_ok());
+
+        // rpc1 missing a field that rpc2 has fails.
+        let missing = TestError::Diff {
+            rpc1: json!({ "a": 1 }),
+            rpc2: json!({ "a": 1, "b": 2 }),
+            args: None,
+        };
+        assert!(report(vec![("t".to_string(), vec![("m".to_string(), Err(missing))])]).is_err());
+
+        // A mismatching field value fails.
+        let mismatch =
+            TestError::Diff { rpc1: json!({ "a": 1 }), rpc2: json!({ "a": 2 }), args: None };
+        assert!(report(vec![("t".to_string(), vec![("m".to_string(), Err(mismatch))])]).is_err());
+
+        // Ignored client-specific extension fields do not fail.
+        let ignored = TestError::Diff {
+            rpc1: json!({ "a": 1 }),
+            rpc2: json!({ "a": 1, "error": "reverted" }),
+            args: None,
+        };
+        assert!(report(vec![("t".to_string(), vec![("m".to_string(), Err(ignored))])]).is_ok());
+
+        // Error mismatches and node errors always fail.
+        let err_diff =
+            TestError::ErrDiff { rpc1: "a".to_string(), rpc2: "b".to_string(), args: None };
+        assert!(report(vec![("t".to_string(), vec![("m".to_string(), Err(err_diff))])]).is_err());
+        let rpc1_err = TestError::Rpc1Err("boom".to_string());
+        assert!(report(vec![("t".to_string(), vec![("m".to_string(), Err(rpc1_err))])]).is_err());
+
+        // Passing results pass.
+        assert!(report(vec![("t".to_string(), vec![("m".to_string(), Ok(()))])]).is_ok());
+    }
 }

--- a/crates/rpc-tester/src/sampling.rs
+++ b/crates/rpc-tester/src/sampling.rs
@@ -3,7 +3,10 @@
 use alloy_primitives::BlockNumber;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-/// Shallowest offset of the near-history window, exclusive of the tip range.
+/// Shallowest offset of the near-history window.
+///
+/// Matches the default tip-range size so default runs do not overlap; callers testing a larger
+/// tip range must filter overlapping samples themselves.
 pub const NEAR_WINDOW_MIN_OFFSET: u64 = 8;
 
 /// Deepest offset of the near-history window.
@@ -15,18 +18,22 @@ pub const NEAR_WINDOW_MAX_OFFSET: u64 = 128;
 
 /// Deep-history offset strata. One block is sampled uniformly from each `(start, end]` offset
 /// range, keeping depth coverage log-spread without fixed blind spots between samples.
+///
+/// Ordered from shallowest to deepest; [`historical_blocks`] relies on this to stop at the first
+/// stratum entirely beyond `head`.
 pub const DEEP_STRATA: [(u64, u64); 4] =
     [(128, 1_024), (1_024, 10_000), (10_000, 100_000), (100_000, 1_000_000)];
 
 /// Returns randomly sampled historical block numbers below `head`.
 ///
 /// Samples `near_samples` blocks uniformly from the near-history window (see
-/// [`NEAR_WINDOW_MAX_OFFSET`]) plus one block per [`DEEP_STRATA`] stratum, skipping any range
-/// that reaches past genesis. The result is sorted ascending and deduplicated, so it may contain
-/// fewer entries than requested. Randomness means repeated runs accumulate coverage instead of
-/// re-testing the same blocks; the caller should log the sampled set.
+/// [`NEAR_WINDOW_MAX_OFFSET`]) plus one block per [`DEEP_STRATA`] stratum, clamping a partially
+/// reachable range to genesis and skipping ranges entirely beyond `head`. The result is sorted
+/// ascending and deduplicated, so it may contain fewer entries than requested. Randomness means
+/// repeated runs accumulate coverage instead of re-testing the same blocks; the caller should log
+/// the sampled set.
 pub fn historical_blocks(head: BlockNumber, near_samples: usize) -> Vec<BlockNumber> {
-    sample_blocks(head, near_samples, &mut Rng::from_entropy())
+    sample_blocks(head, near_samples, &mut Rng::from_clock())
 }
 
 /// Deterministic core of [`historical_blocks`].
@@ -61,7 +68,7 @@ struct Rng(u64);
 
 impl Rng {
     /// Seeds the generator from the system clock.
-    fn from_entropy() -> Self {
+    fn from_clock() -> Self {
         let nanos = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().subsec_nanos();
         let secs = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_secs();
         // Never zero, which would make xorshift degenerate.

--- a/crates/rpc-tester/src/tester.rs
+++ b/crates/rpc-tester/src/tester.rs
@@ -71,36 +71,50 @@ where
     P: Provider<AnyNetwork> + Clone + Send + Sync,
 {
     /// Verifies that results from `rpc1` are at least a superset of `rpc2`.
+    ///
+    /// All suites run to completion before failing so a diff in one does not hide findings in
+    /// another; the first error is returned after every report has been printed.
     pub async fn run(&self, block_range: RangeInclusive<BlockNumber>) -> Result<()> {
-        self.test_per_block(block_range.clone()).await?;
-        self.test_block_range(block_range.clone()).await?;
-        self.test_negative(*block_range.end()).await?;
-        self.test_tags().await?;
-        Ok(())
+        let per_block = self.test_per_block(block_range.clone()).await;
+        let block_range_result = self.test_block_range(block_range.clone()).await;
+        let negative = self.test_negative(*block_range.end()).await;
+        let tags = self.test_tags().await;
+        per_block.and(block_range_result).and(negative).and(tags)
     }
 
     /// Verifies RPC calls applicable to single blocks for each of the given blocks.
     ///
-    /// Unlike [`Self::run`], this does not run block range tests, so the blocks do not need to be
-    /// contiguous. This is intended for sampled historical blocks, see
-    /// [`historical_blocks`](crate::historical_blocks).
+    /// Unlike [`Self::run`], this runs only the per-block suite — no block-range, negative-probe,
+    /// or block-tag tests — so the blocks do not need to be contiguous. This is intended for
+    /// sampled historical blocks, see [`historical_blocks`](crate::historical_blocks).
     pub async fn run_blocks(&self, blocks: impl IntoIterator<Item = BlockNumber>) -> Result<()> {
         self.test_per_block(blocks).await
     }
 
     /// Verifies RPC calls applicable to single blocks.
+    ///
+    /// If a block cannot be fetched, the results collected so far are still reported before the
+    /// fetch error is returned.
     async fn test_per_block(
         &self,
         blocks: impl IntoIterator<Item = BlockNumber>,
     ) -> Result<(), eyre::Error> {
         let mut results = BlockTestResults::new();
+        let mut fetch_err = None;
 
         for block_number in blocks {
             info!(block_number, "testing rpc");
 
             let mut tests = vec![];
 
-            let (block, block_hash, block_tag, block_id) = self.fetch_block(block_number).await?;
+            let (block, block_hash, block_tag, block_id) =
+                match self.fetch_block(block_number).await {
+                    Ok(fetched) => fetched,
+                    Err(err) => {
+                        fetch_err = Some(err);
+                        break;
+                    }
+                };
 
             // EIP-1898 block hash object form with require canonical semantics.
             let canonical_args = (
@@ -171,7 +185,9 @@ where
 
                 // Replaying the transaction as a call at the parent block exercises EVM execution
                 // on historical state, which no data-retrieval method touches. Both nodes get the
-                // identical request, so results (or revert errors) must agree.
+                // identical request, so results (or revert errors) must agree. Note that gas
+                // estimates and access lists are implementation-defined, so those two comparisons
+                // are meaningful primarily for same-client pairs.
                 let call_args =
                     (call_request_json(&tx_json), BlockId::number(block_number.saturating_sub(1)));
                 let estimate_args = call_args.clone();
@@ -275,7 +291,12 @@ where
             let block_results = futures::future::join_all(tests).await;
             results.insert(block_number, block_results);
         }
-        report(results.into_iter().map(|(k, v)| (format!("Block Number {k}"), v)).collect())
+        let report_result =
+            report(results.into_iter().map(|(k, v)| (format!("Block Number {k}"), v)).collect());
+        if let Some(err) = fetch_err {
+            return Err(err);
+        }
+        report_result
     }
 
     /// Verifies RPC calls applicable to block ranges.
@@ -379,7 +400,12 @@ where
         report(vec![("Block tags".to_string(), futures::future::join_all(tests).await)])
     }
 
-    /// Fetches block and block identifiers from `self.truth`.
+    /// Fetches the block and its identifiers from `rpc2`, verifying both nodes agree on the
+    /// canonical hash.
+    ///
+    /// Retries briefly to ride out transient tip reorgs (this narrows the reorg window, it does
+    /// not close it) and errors on persistent divergence or when either node is missing the
+    /// block.
     async fn fetch_block(
         &self,
         block_number: u64,
@@ -421,15 +447,22 @@ where
             last_hashes = (rpc1_hash, Some(block_hash));
         }
 
-        Err(eyre::eyre!(
-            "rpc1 and rpc2 disagree on the canonical hash of block {block_number}: rpc1 {:?} vs rpc2 {:?}",
-            last_hashes.0,
-            last_hashes.1
-        ))
+        // A missing block on rpc1 is a coverage gap (pruned or unsynced history), not a reorg;
+        // report it as such instead of a hash disagreement.
+        match last_hashes {
+            (None, _) => Err(eyre::eyre!("block {block_number} not found on rpc1")),
+            (Some(rpc1_hash), rpc2_hash) => Err(eyre::eyre!(
+                "rpc1 and rpc2 disagree on the canonical hash of block {block_number}: rpc1 {rpc1_hash} vs rpc2 {rpc2_hash:?}",
+            )),
+        }
     }
 
     /// Apply rate limiting if configured.
     /// Sleeps if necessary to maintain the configured rate limit.
+    ///
+    /// The limit is applied per test, and each test issues one request per node, so an endpoint
+    /// serving both roles receives up to twice the configured rate. `eth_getLogs` pagination
+    /// retries and block/receipt prefetches are not throttled.
     async fn apply_rate_limit(&self) {
         if let Some(rps) = self.rate_limit_rps {
             let min_interval = std::time::Duration::from_secs_f64(1.0 / rps as f64);
@@ -459,7 +492,11 @@ where
         Fut: std::future::Future<Output = Result<T, TransportError>> + 'a + Send,
         T: PartialEq + Debug + Serialize,
     {
-        if name.starts_with("reth") && !self.use_reth || name.contains("trace") && !self.use_tracing
+        // The debug namespace is gated together with tracing: `debug_getRaw*` are typically
+        // enabled alongside the trace methods, and running them against nodes without the
+        // namespace would fail every block.
+        if name.starts_with("reth") && !self.use_reth ||
+            (name.contains("trace") || name.starts_with("debug")) && !self.use_tracing
         {
             return (name.to_string(), Ok(()));
         }
@@ -486,9 +523,12 @@ where
                 }
             }
             // Both nodes rejecting the call with the same error response is agreement, e.g. a
-            // deliberate miss-path probe or a namespace disabled on both nodes.
+            // deliberate miss-path probe or a namespace disabled on both nodes. Warn on each
+            // such pass: a run where entire suites "agree on errors" compares no data and would
+            // otherwise be indistinguishable from a verified run.
             (Err(e1), Err(e2)) => {
                 if errors_match(&e1, &e2) {
+                    warn!(name, error = ?e1, "passed via matching errors, no data compared");
                     Ok(())
                 } else {
                     Err(TestError::ErrDiff {
@@ -506,10 +546,13 @@ where
     }
 }
 
-/// Builds an `eth_call` request object from a transaction response's JSON, keeping only the
-/// execution relevant fields.
+/// Builds an `eth_call` request object from a transaction response's JSON, keeping a minimal
+/// subset of fields (`from`, `to`, `gas`, `value`, `input`).
 ///
-/// Fee fields are omitted so the call is exempt from fee and balance validation, and a missing
+/// Access and authorization lists are dropped, so the call is not a faithful replay — but both
+/// nodes receive the identical request, so parity still holds. The gas price is pinned to zero
+/// rather than omitted: the effective price of a fee-less call is client-defined, and a contract
+/// branching on `GASPRICE` would otherwise legitimately diverge across implementations. A missing
 /// `to` naturally maps to a create call.
 fn call_request_json(tx: &serde_json::Value) -> serde_json::Value {
     let mut request = serde_json::Map::new();
@@ -518,6 +561,7 @@ fn call_request_json(tx: &serde_json::Value) -> serde_json::Value {
             request.insert(key.to_string(), value.clone());
         }
     }
+    request.insert("gasPrice".to_string(), serde_json::Value::String("0x0".to_string()));
     serde_json::Value::Object(request)
 }
 
@@ -527,7 +571,14 @@ fn call_request_json(tx: &serde_json::Value) -> serde_json::Value {
 /// such as timeouts are never treated as agreement.
 fn errors_match(e1: &TransportError, e2: &TransportError) -> bool {
     match (e1.as_error_resp(), e2.as_error_resp()) {
-        (Some(r1), Some(r2)) => r1.code == r2.code && r1.message == r2.message,
+        // The data field must match too: reverts surface as identical code/message pairs with
+        // the revert bytes in data, and differing revert data is genuine execution divergence.
+        (Some(r1), Some(r2)) => {
+            r1.code == r2.code &&
+                r1.message == r2.message &&
+                r1.data.as_ref().map(|data| data.get()) ==
+                    r2.data.as_ref().map(|data| data.get())
+        }
         _ => false,
     }
 }
@@ -653,6 +704,14 @@ mod tests {
         })
     }
 
+    fn error_resp_with_data(code: i64, message: &str, data: &str) -> TransportError {
+        TransportError::ErrorResp(ErrorPayload {
+            code,
+            message: message.to_string().into(),
+            data: Some(serde_json::value::RawValue::from_string(data.to_string()).unwrap()),
+        })
+    }
+
     #[test]
     fn matching_error_responses_agree() {
         assert!(errors_match(
@@ -668,6 +727,23 @@ mod tests {
             &error_resp(-32601, "transaction not found")
         ));
         assert!(!errors_match(&error_resp(-32000, "a"), &error_resp(-32000, "b")));
+    }
+
+    #[test]
+    fn different_revert_data_diverges() {
+        // Reverts share code 3 and a generic message; the revert bytes live in data.
+        assert!(!errors_match(
+            &error_resp_with_data(3, "execution reverted", "\"0xdead\""),
+            &error_resp_with_data(3, "execution reverted", "\"0xbeef\"")
+        ));
+        assert!(!errors_match(
+            &error_resp_with_data(3, "execution reverted", "\"0xdead\""),
+            &error_resp(3, "execution reverted")
+        ));
+        assert!(errors_match(
+            &error_resp_with_data(3, "execution reverted", "\"0xdead\""),
+            &error_resp_with_data(3, "execution reverted", "\"0xdead\"")
+        ));
     }
 
     #[test]


### PR DESCRIPTION
An adversarial review of the whole stack (correctness, clarity, design intent) surfaced a set of real issues; this addresses the ones that held up.

Comparison semantics: `errors_match` now also compares the JSON-RPC error `data` field — reverts surface as identical code/message pairs with the revert bytes in `data`, so the previous comparison scored genuinely divergent EVM executions as agreement, which is exactly what the replay suite exists to catch. Each error-parity pass now logs a warning, because a run where an entire namespace "agrees on errors" (e.g. tracing disabled on both nodes) compares no data and was previously indistinguishable from a verified run. `eth_call` replay pins `gasPrice` to zero: the effective price of a fee-less call is client-defined, and a contract reading `GASPRICE` would legitimately diverge across implementations.

Coverage and control flow: `debug_getRaw*` slipped past the `"trace"` substring gate and ran unconditionally, failing every block against nodes without the debug namespace — the whole namespace is now gated behind `--use-tracing`. `run()` short-circuited between suites, so a single per-block diff suppressed the block-range, negative-probe, and tag reports; it now runs all four to completion and returns the first error afterwards, and a mid-run fetch failure reports the already-collected results instead of discarding them. `fetch_block` no longer misreports a block missing on rpc1 as a canonical-hash disagreement.

Reporting: the `ErrDiff`/`Rpc1Err` arms printed the title banner once per failure instead of once per section. The report layer also gained unit tests proving it actually detects missing fields, mismatches, and error diffs — the same-node self-test can never exercise the detection path, so a regression there was previously invisible to CI. Various doc comments and the README were corrected where they had drifted from behavior (fetch_block, run_blocks, sampling clamping, rate-limiter granularity, array-inclusion semantics, archive-state assumption of deep samples), and the live-smoke workflow now documents load-balancer skew and halves its rate limit to account for the tester issuing two requests per test against a single endpoint.

Consciously not changed: exact-equality comparison of `eth_estimateGas`/`eth_createAccessList` (implementation-defined; meaningful for same-client pairs, now documented as such), positional array-inclusion semantics in the report layer (pre-existing, now documented), and rpc2 state errors on deep historical samples still failing the run (archive requirement documented in the README instead).

Stacked on #39. Part of #29