### PR TITLE
feat: add state method coverage

### DIFF
--- a/crates/rpc-tester/src/tester.rs
+++ b/crates/rpc-tester/src/tester.rs
@@ -136,6 +136,15 @@ where
                     if let Some(log) = receipt.inner.inner.logs().first().map(|l| l.address()) {
                         #[rustfmt::skip]
                         tests.push(get_logs!(self, Filter::new().select(block_number).address(log)));
+
+                        // State of the contract that emitted the log at this block. These hit the
+                        // bytecode and (historical) storage paths, which no other call exercises.
+                        #[rustfmt::skip]
+                        let state_calls = vec![
+                            rpc_with_block!(self, get_code_at, log; block_id),
+                            rpc_with_block!(self, get_storage_at, log, U256::ZERO; block_id),
+                        ];
+                        tests.extend(state_calls);
                     }
 
                     if let Some(topic) = receipt
@@ -162,6 +171,9 @@ where
                     rpc!(self, get_transaction_receipt, tx_hash),
                     rpc_with_block!(self, get_transaction_count, tx_from; block_id),
                     rpc_with_block!(self, get_balance, tx_from; block_id),
+                    // Senders are usually EOAs, but EIP-7702 delegations make sender code
+                    // observable.
+                    rpc_with_block!(self, get_code_at, tx_from; block_id),
                     rpc!(self, debug_trace_transaction, tx_hash, tracer_opts),
                 ];
                 tests.extend(tx_calls);

--- a/crates/rpc-tester/tests/same_node.rs
+++ b/crates/rpc-tester/tests/same_node.rs
@@ -15,12 +15,13 @@ use std::time::Duration;
 const ALICE: &str = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
 const BOB: &str = "0x70997970C51812dc3A010C7d01b50e0d17dc79C8";
 
-/// Init code that emits a `LOG1` with a fixed topic and deploys an empty contract:
-/// `PUSH32 topic PUSH1 0 PUSH1 0 LOG1 STOP`.
+/// Init code that stores `1` at slot 0, emits a `LOG1` with a fixed topic, and deploys an empty
+/// contract: `PUSH1 1 PUSH1 0 SSTORE PUSH32 topic PUSH1 0 PUSH1 0 LOG1 STOP`.
 ///
-/// This gives us a receipt with a log so the receipt-derived `eth_getLogs` filters are exercised.
+/// This gives us a receipt with a log so the receipt-derived `eth_getLogs` filters are exercised,
+/// and non-empty contract storage for the state calls.
 const LOG_EMITTER_INIT_CODE: &str =
-    "0x7faaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa60006000a100";
+    "0x60016000557faaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa60006000a100";
 
 fn provider(anvil: &AnvilInstance) -> impl Provider<AnyNetwork> + Clone {
     ProviderBuilder::new()


### PR DESCRIPTION
Replaces #32, which GitHub auto-closed when its base branch was deleted during the stack merge; content is identical, rebased onto main.

Adds eth_getCode and eth_getStorageAt for receipt-log contracts and eth_getCode for tx senders at the tested block, covering bytecode and storage retrieval paths.

Part of #29