### PR TITLE
ci: use the vendored third-party actions from tempoxyz/gh-actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,5 +21,5 @@ jobs:
         with:
           cache-on-failure: true
       # Installs anvil, used by the same-node self-test.
-      - uses: foundry-rs/foundry-toolchain@908c540300062bd5a7e473851cdb4282204cee09 # v1
+      - uses: tempoxyz/gh-actions/actions/setup-foundry@487be2d19b0ba9ae1903143016444ab752c3e939
       - run: cargo test --workspace --all-features --locked


### PR DESCRIPTION
## Summary

Points this repository's workflows at the copies of third-party actions vendored in [tempoxyz/gh-actions](https://github.com/tempoxyz/gh-actions) under `vendor/`, pinned to a full commit SHA. Each vendored copy is an exact upstream commit recorded in [`vendor-manifest.yml`](https://github.com/tempoxyz/gh-actions/blob/487be2d19b0ba9ae1903143016444ab752c3e939/vendor-manifest.yml), with the same inputs and outputs as upstream. This prepares for restricting the org Actions policy to enterprise-owned, `actions/*` and `github/*` actions.

| Before | After (vendored copy) |
| --- | --- |
| `foundry-rs/foundry-toolchain` | [`tempoxyz/gh-actions/actions/setup-foundry`](https://github.com/tempoxyz/gh-actions/tree/487be2d19b0ba9ae1903143016444ab752c3e939/actions/setup-foundry) (verified Foundry releases) |

## Verification

- Every target path exists in the vendored tree at the pinned commit.
- `actionlint` and `zizmor` (regular persona, offline) report no new findings (actionlint 1 -> 1, zizmor 12 -> 12).
